### PR TITLE
updated api token to fix lossy streaming

### DIFF
--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -45,7 +45,7 @@ class Config(object):
         self.quality = quality
         self.api_location = 'https://api.tidalhifi.com/v1/'
         self.api_token = 'P5Xbeo5LFvESeDy6' if self.quality == \
-            Quality.lossless else 'wdgaB1CilGA-S_s2',
+            Quality.lossless else '4zx46pyr9o8qZNRw',
 
 
 class Session(object):


### PR DESCRIPTION
Using the old api token I was unable to get a playable lossy (high or low quality) streaming url.
- Using the old token:
  `rtmp.stream.tidalhifi.com/cfx/st/mp4:1987741/20140909094820_36.m4a?Expires=145529....`
- Using the new token:
  `http://b8.audio.tidal.com//b8/b8427a9c12cb9fe3ae....`
