### PR TITLE
API Updates and new Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ docs/_build
 *.sln
 *.pyproj
 /.cache/
+
+# Eclipse
+.settings
+*.prefs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,22 @@ logging.basicConfig(level=logging.DEBUG)
 
 @pytest.fixture()
 def session():
-    return tidalapi.Session()
+    session = tidalapi.Session()
+    # Trial Mode without login !
+    # session.login('username', 'password')
+    return session
+
+def test_user_subscription(session):
+    if session.is_logged_in:
+        subs = session.get_user_subscription(session.user.id)
+        assert subs.type in ['PREMIUM', 'HIFI']
+
+def test_user_playlists(session):
+    if session.is_logged_in:
+        userpl = session.user.playlists()
+        assert len(userpl) > 0
+        tracks = session.get_playlist_items(userpl[0].id)
+        assert len(tracks) > 0
 
 def test_artist(session):
     artist_id = 18888
@@ -35,7 +50,7 @@ def test_artist(session):
 
 def test_get_artist_albums(session):
     albums = session.get_artist_albums(18888)
-    assert albums[0].name == 'Mala in Cuba'
+    assert any([a.name == 'Mala in Cuba' for a in albums])
 
 def test_get_artist_albums_ep_single(session):
     albums = session.get_artist_albums_ep_singles(18888)
@@ -69,6 +84,16 @@ def test_artist_radio(session):
     tracks = session.get_artist_radio(18888)
     assert len(tracks) > 0
 
+def test_get_artist_top(session):
+    tracks = session.get_artist_top_tracks(18888)
+    assert len(tracks) > 0
+
+def test_get_artist_videos(session):
+    videos = session.get_artist_videos(1566)
+    assert videos[0].artist.name == 'Beyoncé'
+    assert isinstance(videos[0], tidalapi.Video)
+    assert any([v.name == 'LEMONADE' for v in videos])
+
 def test_search(session):
     res = session.search('artist', 'mala')
     assert res.artists[0].name == "Mala"
@@ -81,6 +106,74 @@ def test_album_image(session):
     artist = session.get_album(16909093)
     assert requests.get(artist.image).status_code == 200
 
+def test_get_playlist(session):
+    playlist = session.get_playlist('56c28e48-5d09-4fb0-812e-c6c7c6647dcf')
+    assert 'TIDAL' in playlist.name 
+    assert playlist.numberOfItems > 0
+    assert playlist.numberOfTracks > 0
+    assert playlist.numberOfVideos == 0
+    playlist = session.get_playlist('7ba7548e-a5d9-4387-9ba1-d8aea06d3369')
+    assert playlist.numberOfItems > 0
+    if session.is_logged_in:
+        assert playlist.numberOfTracks == 0
+        assert playlist.numberOfVideos > 0
+
 def test_playlist_image(session):
     playlist = session.get_playlist('33136f5a-d93a-4469-9353-8365897aaf94')
     assert requests.get(playlist.image).status_code == 200
+
+def test_get_playlist_tracks(session):
+    items = session.get_playlist_tracks('56c28e48-5d09-4fb0-812e-c6c7c6647dcf')
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Track)
+
+def test_get_playlist_items(session):
+    items = session.get_playlist_tracks('7ba7548e-a5d9-4387-9ba1-d8aea06d3369')
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Track)
+    items = session.get_playlist_items('7ba7548e-a5d9-4387-9ba1-d8aea06d3369')
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Video)
+
+def test_get_genres(session):
+    items = session.get_genres()
+    assert len(items) > 0
+
+def test_get_genres_items(session):
+    items = session.get_genre_items('pop', 'tracks')
+    assert len(items) > 0
+
+def test_get_moods(session):
+    items = session.get_moods()
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Category)
+
+def test_get_movies(session):
+    items = session.get_movies()
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Video)
+
+def test_get_shows(session):
+    items = session.get_shows()
+    assert len(items) > 0
+    assert isinstance(items[0], tidalapi.Playlist)
+
+def test_get_track_url(session):
+    items = session.get_category_content('featured', 'new', 'tracks', offset=0, limit=3)
+    assert len(items) > 0
+    url = session.get_media_url(items[0].id)
+    assert url.startswith('http') or url.startswith('rtmp')
+
+def test_get_video_url(session):
+    items = session.get_category_content('featured', 'new', 'videos', offset=0, limit=3)
+    assert len(items) > 0
+    url = session.get_video_url(items[0].id)
+    assert url.startswith('http') or url.startswith('rtmp')
+
+def test_offset(session):
+    items1 = session.get_category_content('featured', 'new', 'tracks', offset=0, limit=30)
+    assert len(items1) == 30
+    items2 = session.get_category_content('featured', 'new', 'tracks', offset=10, limit=10)
+    assert len(items2) == 10
+    assert items1[10].id == items2[0].id
+    assert items1[19].id == items2[9].id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,7 @@ logging.basicConfig(level=logging.DEBUG)
 @pytest.fixture()
 def session():
     session = tidalapi.Session()
+    session.country_code = session.local_country_code()
     # Trial Mode without login !
     # session.login('username', 'password')
     return session
@@ -79,6 +80,12 @@ def test_get_album_tracks(session):
     assert tracks[-1].duration == 338
     assert tracks[0].artist.name == 'Mala'
     assert tracks[0].album.name == 'Mala in Cuba'
+
+def test_get_album_videos(session):
+    album = session.get_album(24274814)
+    assert album.numberOfVideos > 0
+    videos = session.get_album_items(24274814, ret='videos')
+    assert isinstance(videos[0], tidalapi.Video)
 
 def test_artist_radio(session):
     tracks = session.get_artist_radio(18888)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -226,6 +226,27 @@ class Session(object):
     def get_album_tracks(self, album_id):
         return self._map_request('albums/%s/tracks' % album_id, ret='tracks')
 
+    def get_album_items(self, album_id, ret='playlistitems'):
+        offset = 0
+        remaining = 9999
+        result = []
+        # Number of Items is limited to 100, so read multiple times if more than 100 entries are requested
+        while remaining > 0:
+            items = self._map_request('albums/%s/items' % album_id, params={'offset': offset, 'limit': 100}, ret='playlistitems')
+            if items:
+                if remaining == 9999:
+                    remaining = items[0]._totalNumberOfItems
+                remaining -= len(items)
+                result += items
+            offset += 100
+        if ret.startswith('track'):
+            # Return tracks only
+            result = [item for item in result if isinstance(item, Track)]
+        elif ret.startswith('video'):
+            # Return videos only
+            result = [item for item in result if isinstance(item, Video)]
+        return result
+
     def get_artist(self, artist_id):
         return self._map_request('artists/%s' % artist_id, ret='artist')
 

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -704,6 +704,21 @@ class User(object):
     def delete_playlist(self, playlist_id):
         return self._session.request('DELETE', 'playlists/%s' % playlist_id).ok
 
+    def rename_playlist(self, playlist, title, description=''):
+        if not isinstance(playlist, Playlist):
+            playlist = self._session.get_playlist(playlist)
+        ok = False
+        if not playlist._etag:
+            # Read Playlist to get ETag
+            playlist = self._session.get_playlist(playlist.id)
+        if playlist and playlist._etag:
+            headers = {'If-None-Match': '%s' % playlist._etag}
+            data = {'title': title, 'description': description}
+            ok = self._session.request('POST', 'playlists/%s' % playlist.id, data=data, headers=headers).ok
+        else:
+            log.debug('Got no ETag for playlist %s' & playlist.title)
+        return ok
+
     def add_playlist_entries(self, playlist=None, item_ids=[]):
         if not isinstance(playlist, Playlist):
             playlist = self._session.get_playlist(playlist)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -197,7 +197,7 @@ class Session(object):
 
     def get_playlist_tracks(self, playlist_id, offset=0, limit=9999):
         items = self._map_request('playlists/%s/tracks' % playlist_id, params={'offset': offset, 'limit': limit}, ret='tracks')
-        track_no = offset + 1
+        track_no = offset
         for item in items:
             item._playlist_id = playlist_id
             item._playlist_pos = track_no
@@ -224,7 +224,7 @@ class Session(object):
                     item._playlist_pos = track_no
                     item._etag = playlist._etag
                     item._playlist_name = playlist.title
-                    item._is_user_playlist = playlist.type == 'USER'
+                    item._playlist_type = playlist.type
                     track_no += 1
                 remaining -= len(items)
                 result += items
@@ -743,8 +743,8 @@ class User(object):
             entry_no = None
             items = self._session.get_playlist_items(playlist_id)
             for item in items:
-                if item.id == item_id:
-                    entry_no = item._user_playlist_tack_no
+                if str(item.id) == str(item_id):
+                    entry_no = item._playlist_pos
             if entry_no == None:
                 return False
         # Read Playlist to get ETag

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -17,12 +17,15 @@
 
 from __future__ import unicode_literals
 
+import re
 import datetime
 import json
 import logging
 import requests
-from collections import namedtuple
-from .models import Artist, Album, Track, Playlist, SearchResult, Category, Role
+from requests.packages import urllib3
+from collections import Iterable
+from .models import UserInfo, Subscription, SubscriptionType, Quality
+from .models import Artist, Album, Track, Video, Playlist, BrowsableMedia, PlayableMedia, Promotion, SearchResult, Category
 try:
     from urlparse import urljoin
 except ImportError:
@@ -31,77 +34,160 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-Api = namedtuple('API', ['location', 'token'])
-
-
-class Quality(object):
-    lossless = 'LOSSLESS'
-    high = 'HIGH'
-    low = 'LOW'
-
 
 class Config(object):
     def __init__(self, quality=Quality.high):
         self.quality = quality
-        self.api_location = 'https://api.tidalhifi.com/v1/'
-        self.api_token = 'P5Xbeo5LFvESeDy6' if self.quality == \
-            Quality.lossless else 'wdgaB1CilGA-S_s2',
+        self.api_location = 'https://api.tidal.com/v1/'
+        self.api_token = 'wdgaB1CilGA-S_s2'     # Web Token, Plays m4a and Videos, Lossless audio is encrypted
+        self.flac_token = None                  # Token that is used for FLAC-Streaming
+        self.flac_tokens = ['oIaGpqT_vQPnTr0Q', # Old Wimp FLAC Token that still works for FLAC Streaming
+                            'P5Xbeo5LFvESeDy6', # Streams FLAC, m4a and Videos over HTTP. Seems to be disabled since September 2016
+                            '_KM2HixcUBZtmktH', # Other old Token that may work
+                            '4zx46pyr9o8qZNRw'] # This seems to be an old working Token, but many FLAC streams don't work
+        self.preview_token = "8C7kRFdkaRp0dLBp" # Token for Preview Mode
 
 
 class Session(object):
 
     def __init__(self, config=Config()):
-        self.session_id = None
-        self.country_code = None
-        self.user = None
-        self._config = config
         """:type _config: :class:`Config`"""
+        self.logout()
+        self._config = config
+        self.country_code = 'US'   # Enable Trial Mode
+        urllib3.disable_warnings() # Disable OpenSSL Warnings in URLLIB3
 
-    def load_session(self, session_id, country_code, user_id):
+    def logout(self):
+        self.session_id = None
+        self.api_session_id = None
+        # Country Code can stay in config (for Trial Mode after logout)
+        # self.country_code = None
+        self.user = None
+
+    def load_session(self, session_id, country_code, user_id=None, subscription_type=None, api_session_id=None):
         self.session_id = session_id
+        self.api_session_id = api_session_id if api_session_id else session_id
         self.country_code = country_code
-        self.user = User(self, id=user_id)
+        if not self.country_code:
+            # Set Local Country Code to enable Trial Mode 
+            self.country_code = self.local_country_code()
+        if user_id:
+            self.user = self.init_user(user_id=user_id, subscription_type=subscription_type)
+        else:
+            self.user = None
 
-    def login(self, username, password):
+    def login(self, username, password, subscription_type=None):
+        if not username or not password:
+            self.logout()
+            return False
         url = urljoin(self._config.api_location, 'login/username')
-        params = {'token': self._config.api_token}
+        headers = { "X-Tidal-Token": self._config.api_token}
         payload = {
             'username': username,
             'password': password,
         }
-        r = requests.post(url, data=payload, params=params)
-        r.raise_for_status()
+        r = requests.post(url, data=payload, headers=headers)
+        if not r.ok:
+            try:
+                msg = r.json().get('userMessage')
+            except:
+                msg = r.reason
+            log.error(msg)
+            self.logout()
+            r.raise_for_status()
         body = r.json()
         self.session_id = body['sessionId']
+        self.api_session_id = self.session_id
         self.country_code = body['countryCode']
-        self.user = User(self, id=body['userId'])
+        self.user = self.init_user(user_id=body['userId'], subscription_type=subscription_type)
+        if not self.user.subscription.type:
+            # Set Subscription Type corresponding to the given playback quality
+            self.user.subscription.type = SubscriptionType.hifi if self._config.quality == Quality.lossless else SubscriptionType.premium
+        if self.user.subscription.type == SubscriptionType.hifi:
+            # For FLAC Streaming we needs a second Login Session ID
+            for self._config.flac_token in self._config.flac_tokens:
+                headers = { "X-Tidal-Token": self._config.flac_token }
+                r = requests.post(url, data=payload, headers=headers)
+                if not r.ok:
+                    try:
+                        msg = r.json().get('userMessage')
+                    except:
+                        msg = r.reason
+                    log.error('FLAC-Token "%s" didn\'t work' % self._config.flac_token)
+                    log.debug(msg)
+                if r.ok:
+                    try:
+                        # Take the second session
+                        self.session_id = r.json()['sessionId']
+                        if self.session_id:
+                            log.debug('Using FLAC-Token "%s"' % self._config.flac_token)
+                            break
+                    except:
+                        pass
+            if self.session_id == self.api_session_id:
+                log.error('No FLAC-Token works anymore. Normal API-Key will be used for streaming.')
         return True
+
+    def init_user(self, user_id, subscription_type):
+        return User(self, user_id=user_id, subscription_type=subscription_type)
+
+    def local_country_code(self):
+        url = urljoin(self._config.api_location, 'country/context')
+        headers = { "X-Tidal-Token": self._config.api_token}
+        r = requests.request('GET', url, params={'countryCode': 'WW'}, headers=headers)
+        if not r.ok:
+            return 'US'
+        return r.json().get('countryCode')
+
+    @property
+    def is_logged_in(self):
+        return True if self.session_id and self.api_session_id and self.country_code and self.user else False
 
     def check_login(self):
         """ Returns true if current session is valid, false otherwise. """
-        if self.user is None or not self.user.id or not self.session_id:
+        if not self.is_logged_in:
             return False
-        url = urljoin(self._config.api_location, 'users/%s/subscription' % self.user.id)
-        return requests.get(url, params={'sessionId': self.session_id}).ok
+        self.user.subscription = self.get_user_subscription(self.user.id)
+        return True if self.user.subscription != None else False
 
-    def request(self, method, path, params=None, data=None):
+    def request(self, method, path, params=None, data=None, headers=None):
+        request_headers = {}
         request_params = {
-            'sessionId': self.session_id,
-            'countryCode': self.country_code,
-            'limit': '999',
+            'countryCode': self.country_code
         }
+        if headers:
+            request_headers.update(headers)
         if params:
             request_params.update(params)
+        if request_params.get('offset', 1) == 0:
+            request_params.pop('offset', 1) # Remove Zero Offset from Params
         url = urljoin(self._config.api_location, path)
-        r = requests.request(method, url, params=request_params, data=data)
-        log.debug("request: %s" % r.request.url)
+        if self.is_logged_in:
+            # Request with API Session if SessionId is not given in headers parameter
+            if not 'X-Tidal-SessionId' in request_headers:
+                request_headers.update({'X-Tidal-SessionId': self.api_session_id})
+        else:
+            # Request with Preview-Token. Remove SessionId if given via headers parameter
+            request_headers.pop('X-Tidal-SessionId', None)
+            request_params.update({'token': self._config.preview_token})
+        r = requests.request(method, url, params=request_params, data=data, headers=request_headers)
+        log.debug("%s %s" % (method, r.request.url))
+        if not r.ok:
+            log.error(r.url)
+            try:
+                log.error(r.json().get('userMessage'))
+            except:
+                log.error(r.reason)
         r.raise_for_status()
-        if r.content:
-            log.debug("response: %s" % json.dumps(r.json(), indent=4))
+        if r.content and log.isEnabledFor(logging.INFO):
+            log.info("response: %s" % json.dumps(r.json(), indent=4))
         return r
 
     def get_user(self, user_id):
         return self._map_request('users/%s' % user_id, ret='user')
+
+    def get_user_subscription(self, user_id):
+        return self._map_request('users/%s/subscription' % user_id, ret='subscription')
 
     def get_user_playlists(self, user_id):
         return self._map_request('users/%s/playlists' % user_id, ret='playlists')
@@ -109,8 +195,47 @@ class Session(object):
     def get_playlist(self, playlist_id):
         return self._map_request('playlists/%s' % playlist_id, ret='playlist')
 
-    def get_playlist_tracks(self, playlist_id):
-        return self._map_request('playlists/%s/tracks' % playlist_id, ret='tracks')
+    def get_playlist_tracks(self, playlist_id, offset=0, limit=9999):
+        items = self._map_request('playlists/%s/tracks' % playlist_id, params={'offset': offset, 'limit': limit}, ret='tracks')
+        track_no = offset + 1
+        for item in items:
+            item._playlist_id = playlist_id
+            item._playlist_pos = track_no
+            track_no += 1
+        return items
+
+    def get_playlist_items(self, playlist_id=None, playlist=None, offset=0, limit=9999, ret='playlistitems'):
+        if not playlist:
+            playlist = self.get_playlist(playlist_id)
+        # Don't read empty playlists
+        if not playlist or playlist.numberOfItems == 0:
+            return []
+        itemCount = playlist.numberOfItems - offset
+        remaining = min(itemCount,limit)
+        result = []
+        # Number of Items is limited to 100, so read multiple times if more than 100 entries are requested
+        while remaining > 0:
+            nextLimit = min(100,remaining)
+            items = self._map_request('playlists/%s/items' % playlist.id, params={'offset': offset, 'limit': nextLimit}, ret='playlistitems')
+            if items:
+                track_no = offset
+                for item in items:
+                    item._playlist_id = playlist.id
+                    item._playlist_pos = track_no
+                    item._etag = playlist._etag
+                    item._playlist_name = playlist.title
+                    item._is_user_playlist = playlist.type == 'USER'
+                    track_no += 1
+                remaining -= len(items)
+                result += items
+            offset += 100
+        if ret.startswith('track'):
+            # Return tracks only
+            result = [item for item in result if isinstance(item, Track)]
+        elif ret.startswith('video'):
+            # Return videos only
+            result = [item for item in result if isinstance(item, Video)]
+        return result
 
     def get_album(self, album_id):
         return self._map_request('albums/%s' % album_id, ret='album')
@@ -121,227 +246,511 @@ class Session(object):
     def get_artist(self, artist_id):
         return self._map_request('artists/%s' % artist_id, ret='artist')
 
-    def get_artist_albums(self, artist_id):
-        return self._map_request('artists/%s/albums' % artist_id, ret='albums')
+    def get_artist_albums(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/albums' % artist_id, params={'offset': offset, 'limit': limit}, ret='albums')
 
-    def get_artist_albums_ep_singles(self, artist_id):
-        params = {'filter': 'EPSANDSINGLES'}
-        return self._map_request('artists/%s/albums' % artist_id, params, ret='albums')
+    def get_artist_albums_ep_singles(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/albums' % artist_id, params={'filter': 'EPSANDSINGLES', 'offset': offset, 'limit': limit}, ret='albums')
 
-    def get_artist_albums_other(self, artist_id):
-        params = {'filter': 'COMPILATIONS'}
-        return self._map_request('artists/%s/albums' % artist_id, params, ret='albums')
+    def get_artist_albums_other(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/albums' % artist_id, params={'filter': 'COMPILATIONS', 'offset': offset, 'limit': limit}, ret='albums')
 
-    def get_artist_top_tracks(self, artist_id):
-        return self._map_request('artists/%s/toptracks' % artist_id, ret='tracks')
+    def get_artist_top_tracks(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/toptracks' % artist_id, params={'offset': offset, 'limit': limit}, ret='tracks')
+
+    def get_artist_videos(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/videos' % artist_id, params={'offset': offset, 'limit': limit}, ret='videos')
+
+    def _cleanup_text(self, text):
+        clean_text = re.sub(r"\[.*\]", ' ', text)         # Remove Tags: [wimpLink ...] [/wimpLink]
+        clean_text = re.sub(r"<br.>", '\n', clean_text)   # Replace Tags: <br/> with NewLine
+        return clean_text
 
     def get_artist_bio(self, artist_id):
-        return self.request('GET', 'artists/%s/bio' % artist_id).json()['text']
+        bio = self.request('GET', 'artists/%s/bio' % artist_id, params={'includeImageLinks': 'false'}).json()
+        return self._cleanup_text(bio.get('text', ''))
 
-    def get_artist_similar(self, artist_id):
-        return self._map_request('artists/%s/similar' % artist_id, ret='artists')
+    def get_artist_info(self, artist_id):
+        bio = self.request('GET', 'artists/%s/bio' % artist_id, params={'includeImageLinks': 'false'}).json()
+        if bio.get('summary', None):
+            bio.update({'summary': self._cleanup_text(bio.get('summary', ''))})
+        if bio.get('text', None):
+            bio.update({'text': self._cleanup_text(bio.get('text', ''))})
+        return bio
 
-    def get_artist_radio(self, artist_id):
-        return self._map_request('artists/%s/radio' % artist_id, params={'limit': 100}, ret='tracks')
+    def get_artist_similar(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/similar' % artist_id, params={'offset': offset, 'limit': limit}, ret='artists')
 
-    def get_featured(self):
-        items = self.request('GET', 'promotions').json()['items']
-        return [_parse_featured_playlist(item) for item in items if item['type'] == 'PLAYLIST']
+    def get_artist_radio(self, artist_id, offset=0, limit=999):
+        return self._map_request('artists/%s/radio' % artist_id, params={'offset': offset, 'limit': limit}, ret='tracks')
 
-    def get_featured_items(self, content_type, group):
-        return self._map_request('/'.join(['featured', group, content_type]), ret=content_type)
+    def get_artist_playlists(self, artist_id):
+        return self._map_request('artists/%s/playlistscreatedby' % artist_id, ret='playlists')
+
+    def get_featured(self, group=None, types=['PLAYLIST'], limit=999):
+        params = {'limit': limit,
+                  'clientType': 'BROWSER',
+                  'subscriptionType': SubscriptionType.hifi if not self.is_logged_in else self.user.subscription.type}
+        if group:
+            params.update({'group': group})      # RISING | DISCOVERY | NEWS
+        items = self.request('GET', 'promotions', params=params).json()['items']
+        return [self._parse_promotion(item) for item in items if item['type'] in types]
+
+    def get_category_items(self, group):
+        items = map(self._parse_category, self.request('GET', group).json())
+        for item in items:
+            item._group = group
+        return items
+
+    def get_category_content(self, group, path, content_type, offset=0, limit=999):
+        return self._map_request('/'.join([group, path, content_type]), params={'offset': offset, 'limit': limit}, ret=content_type)
+
+    def get_featured_items(self, content_type, group, path='featured', offset=0, limit=999):
+        return self.get_category_content(path, group, content_type, offset, limit)
 
     def get_moods(self):
-        return map(_parse_moods, self.request('GET', 'moods').json())
+        return self.get_category_items('moods')
 
     def get_mood_playlists(self, mood_id):
-        return self._map_request('/'.join(['moods', mood_id, 'playlists']), ret='playlists')
+        return self.get_category_content('moods', mood_id, 'playlists')
 
     def get_genres(self):
-        return map(_parse_genres, self.request('GET', 'genres').json())
+        return self.get_category_items('genres')
 
     def get_genre_items(self, genre_id, content_type):
-        return self._map_request('/'.join(['genres', genre_id, content_type]), ret=content_type)
+        return self.get_category_content('genres', genre_id, content_type)
 
-    def get_track_radio(self, track_id):
-        return self._map_request('tracks/%s/radio' % track_id, params={'limit': 100}, ret='tracks')
+    def get_movies(self):
+        items = self.get_category_items('movies')
+        movies = []
+        for item in items:
+            movies += self.get_category_content('movies', item.path, 'videos')
+        return movies
 
-    def get_track(self, track_id):
-        return self._map_request('tracks/%s' % track_id, ret='track')
+    def get_shows(self):
+        items = self.get_category_items('shows')
+        shows = []
+        for item in items:
+            shows += self.get_category_content('shows', item.path, 'playlists')
+        return shows
 
-    def _map_request(self, url, params=None, ret=None):
-        json_obj = self.request('GET', url, params).json()
-        parse = None
-        if ret.startswith('artist'):
-            parse = _parse_artist
-        elif ret.startswith('album'):
-            parse = _parse_album
-        elif ret.startswith('track'):
-            parse = _parse_track
-        elif ret.startswith('user'):
-            raise NotImplementedError()
-        elif ret.startswith('playlist'):
-            parse = _parse_playlist
+    def get_track_radio(self, track_id, offset=0, limit=999):
+        return self._map_request('tracks/%s/radio' % track_id, params={'offset': offset, 'limit': limit}, ret='tracks')
 
-        items = json_obj.get('items')
-        if items is None:
-            return parse(json_obj)
-        elif len(items) > 0 and 'item' in items[0]:
-            return list(map(parse, [item['item'] for item in items]))
+    def get_track(self, track_id, withAlbum=False):
+        item = self._map_request('tracks/%s' % track_id, ret='track')
+        if item.album and withAlbum:
+            album = self.get_album(item.album.id)
+            if album:
+                item.album = album
+        return item
+
+    def get_video(self, video_id):
+        return self._map_request('videos/%s' % video_id, ret='video')
+
+    def get_recommended_items(self, content_type, item_id, offset=0, limit=999):
+        return self._map_request('%s/%s/recommendations' % (content_type, item_id), params={'offset': offset, 'limit': limit}, ret=content_type)
+
+    def _map_request(self, url, method='GET', params=None, data=None, headers=None, ret=None):
+        r = self.request(method, url, params=params, data=data, headers=headers)
+        if not r.ok:
+            return [] if ret.endswith('s') else None
+        json_obj = r.json()
+        if 'items' in json_obj:
+            items = json_obj.get('items')
+            result = []
+            offset = 0
+            if params and 'offset' in params:
+                offset = params.get('offset')
+            itemPosition = offset
+            try:
+                numberOfItems = int('0%s' % json_obj.get('totalNumberOfItems')) if 'totalNumberOfItems' in json_obj else 9999
+            except:
+                numberOfItems = 9999
+            log.debug('NumberOfItems=%s, %s items in list' % (numberOfItems, len(items)))
+            for item in items:
+                retType = ret
+                if 'type' in item and ret.startswith('playlistitem'):
+                    retType = item['type']
+                if 'item' in item:
+                    item = item['item']
+                elif 'track' in item and ret.startswith('track'):
+                    item = item['track']
+                elif 'video' in item and ret.startswith('video'):
+                    item = item['video']
+                nextItem = self._parse_one_item(item, retType)
+                if isinstance(nextItem, BrowsableMedia):
+                    nextItem._itemPosition = itemPosition
+                    nextItem._offset = offset
+                    nextItem._totalNumberOfItems = numberOfItems
+                result.append(nextItem)
+                itemPosition = itemPosition + 1
         else:
-            return list(map(parse, items))
+            result = self._parse_one_item(json_obj, ret)
+            if isinstance(result, Playlist) and result.type == 'USER':
+                # Get ETag of Playlist which must be used to add/remove entries of playlists
+                try: 
+                    result._etag = r.headers._store['etag'][1]
+                except:
+                    result._etag = None
+                    log.error('No ETag in response header for playlist "%s" (%s)' % (json_obj.get('title'), json_obj.get('id')))
+        return result
 
-    def get_media_url(self, track_id):
-        params = {'soundQuality': self._config.quality}
-        r = self.request('GET', 'tracks/%s/streamUrl' % track_id, params)
-        return r.json()['url']
+    def get_media_url(self, track_id, quality=None):
+        if self.is_logged_in:
+            params = {'soundQuality': quality if quality else self._config.quality}
+            # Request with second SessionId because FLAC Streaming needs a different Login Token
+            r = self.request('GET', 'tracks/%s/streamUrl' % track_id, params, headers={'X-Tidal-SessionId': self.session_id})
+            if r.ok:
+                json_obj = r.json()
+                url = json_obj.get('url', None)
+                if params.get('soundQuality') == Quality.lossless and json_obj.get('encryptionKey', False) and not '.flac' in url:
+                    # Got Encrypted Stream. Retry with HIGH Quality
+                    log.warning(url)
+                    log.warning('Got encryptionKey "%s" for track %s, trying HIGH Quality ...' % (json_obj.get('encryptionKey', ''), track_id))
+                    return self.get_media_url(track_id, quality=Quality.high)
+        else:
+            r = self.request('GET', 'tracks/%s/previewurl' % track_id)
+            url = r.json().get('url', None)
+        if not r.ok:
+            r.raise_for_status()
+        return url
 
-    def search(self, field, value):
+    def get_video_url(self, video_id):
+        if self.is_logged_in:
+            r = self.request('GET', 'videos/%s/streamUrl' % video_id)
+        else:
+            r = self.request('GET', 'videos/%s/previewurl' % video_id)
+        if not r.ok:
+            r.raise_for_status()
+        return r.json().get('url', None)
+
+    def search(self, field, value, limit=50):
         params = {
             'query': value,
-            'limit': 50,
+            'limit': limit,
         }
-        if field not in ['artist', 'album', 'playlist', 'track']:
-            raise ValueError('Unknown field \'%s\'' % field)
+        if isinstance(field, basestring):
+            what = field.upper()
+            params.update({'types': what if what == 'ALL' or what.endswith('S') else what + 'S'})
+        elif isinstance(field, Iterable):
+            params.update({'types': ','.join(field)})
+        return self._map_request('search', params=params, ret='search')
 
-        ret_type = field + 's'
-        url = 'search/' + field + 's'
-        result = self._map_request(url, params, ret=ret_type)
-        return SearchResult(**{ret_type: result})
+#------------------------------------------------------------------------------
+# Parse JSON Data into Media-Item-Objects
+#------------------------------------------------------------------------------
 
+    def _parse_one_item(self, json_obj, ret=None):
+        parse = None
+        if ret.startswith('user'):
+            parse = self._parse_user
+        elif ret.startswith('subscription'):
+            parse = self._parse_subscription
+        elif ret.startswith('artist'):
+            parse = self._parse_artist
+        elif ret.startswith('album'):
+            parse = self._parse_album
+        elif ret.startswith('track'):
+            parse = self._parse_track
+        elif ret.startswith('video'):
+            parse = self._parse_video
+        elif ret.startswith('playlist'):
+            parse = self._parse_playlist
+        elif ret.startswith('category'):
+            parse = self._parse_category
+        elif ret.startswith('search'):
+            parse = self._parse_search
+        else:
+            raise NotImplementedError()
+        oneItem = parse(json_obj)
+        return oneItem
 
-def _parse_artist(json_obj):
-    return Artist(id=json_obj['id'], name=json_obj['name'], role=Role(json_obj['type']))
+    def _parse_user(self, json_obj):
+        return UserInfo(**json_obj)
 
+    def _parse_subscription(self, json_obj):
+        return Subscription(**json_obj)
 
-def _parse_artists(json_obj):
-    return list(map(_parse_artist, json_obj))
+    def _parse_artist(self, json_obj):
+        artist = Artist(**json_obj)
+        if self.is_logged_in and self.user.favorites:
+            artist._isFavorite = self.user.favorites.isFavoriteArtist(artist.id)
+        return artist
 
+    def _parse_all_artists(self, artist_id, json_obj):
+        allArtists = []
+        ftArtists = []
+        for item in json_obj:
+            nextArtist = self._parse_artist(item)
+            allArtists.append(nextArtist)
+            if nextArtist.id <> artist_id:
+                ftArtists.append(nextArtist)
+        return (allArtists, ftArtists)
 
-def _parse_album(json_obj, artist=None, artists=None):
-    if artist is None:
-        artist = _parse_artist(json_obj['artist'])
-    if artists is None:
-        artists = _parse_artists(json_obj['artists'])
-    kwargs = {
-        'id': json_obj['id'],
-        'name': json_obj['title'],
-        'num_tracks': json_obj.get('numberOfTracks'),
-        'duration': json_obj.get('duration'),
-        'artist': artist,
-        'artists': artists,
-    }
-    if 'releaseDate' in json_obj:
-        try:
-            kwargs['release_date'] = datetime.datetime(*map(int, json_obj['releaseDate'].split('-')))
-        except ValueError:
-            pass
-    return Album(**kwargs)
+    def _parse_album(self, json_obj, artist=None):
+        album = Album(**json_obj)
+        if artist:
+            album.artist = artist
+        elif 'artist' in json_obj:
+            album.artist = self._parse_artist(json_obj['artist'])
+        elif 'artists' in json_obj:
+            album.artist = self._parse_artist(json_obj['artists'][0])
+        if 'artists' in json_obj:
+            album.artists, album._ftArtists = self._parse_all_artists(album.artist.id, json_obj['artists'])
+        else:
+            album.artists = [album.artist]
+            album._ftArtists = []
+        if self.is_logged_in and self.user.favorites:
+            album._isFavorite = self.user.favorites.isFavoriteAlbum(album.id)
+        return album
 
+    def _parse_playlist(self, json_obj):
+        playlist = Playlist(**json_obj)
+        if self.is_logged_in and self.user.favorites:
+            playlist._isFavorite = self.user.favorites.isFavoritePlaylist(playlist.id)
+        return playlist
 
-def _parse_featured_playlist(json_obj):
-    kwargs = {
-        'id': json_obj['artifactId'],
-        'name': json_obj['header'],
-        'description': json_obj['text'],
-    }
-    return Playlist(**kwargs)
+    def _parse_promotion(self, json_obj):
+        item = Promotion(**json_obj)
+        if self.is_logged_in and self.user.favorites:
+            if item.type == 'ALBUM':
+                item._isFavorite = self.user.favorites.isFavoriteAlbum(item.id)
+            elif item.type == 'PLAYLIST':
+                item._isFavorite = self.user.favorites.isFavoritePlaylist(item.id)
+            elif item.type == 'VIDEO':
+                item._isFavorite = self.user.favorites.isFavoriteVideo(item.id)
+        return item
 
+    def _parse_track(self, json_obj):
+        track = Track(**json_obj)
+        if 'artist' in json_obj:
+            track.artist = self._parse_artist(json_obj['artist'])
+        elif 'artists' in json_obj:
+            track.artist = self._parse_artist(json_obj['artists'][0])
+        if 'artists' in json_obj:
+            track.artists, track._ftArtists = self._parse_all_artists(track.artist.id, json_obj['artists'])
+        else:
+            track.artists = [track.artist]
+            track._ftArtists = []
+        track.album = self._parse_album(json_obj['album'], artist=track.artist)
+        if self.is_logged_in and self.user.favorites:
+            track._isFavorite = self.user.favorites.isFavoriteTrack(track.id)
+        return track
 
-def _parse_playlist(json_obj):
-    kwargs = {
-        'id': json_obj['uuid'],
-        'name': json_obj['title'],
-        'description': json_obj['description'],
-        'num_tracks': int(json_obj['numberOfTracks']),
-        'duration': int(json_obj['duration']),
-        'is_public': json_obj['publicPlaylist'],
-        #TODO 'creator': _parse_user(json_obj['creator']),
-    }
-    return Playlist(**kwargs)
+    def _parse_video(self, json_obj):
+        video = Video(**json_obj)
+        if 'artist' in json_obj:
+            video.artist = self._parse_artist(json_obj['artist'])
+        elif 'artists' in json_obj:
+            video.artist = self._parse_artist(json_obj['artists'][0])
+        if 'artists' in json_obj:
+            video.artists, video._ftArtists = self._parse_all_artists(video.artist.id, json_obj['artists'])
+            if not 'artist' in json_obj and len(video.artists) > 0:
+                video.artist = video.artists[0]
+        else:
+            video.artists = [video.artist]
+            video._ftArtists = []
+        if self.is_logged_in and self.user.favorites:
+            video._isFavorite = self.user.favorites.isFavoriteVideo(video.id)
+        return video
 
+    def _parse_category(self, json_obj):
+        return Category(**json_obj)
 
-def _parse_track(json_obj):
-    artist = _parse_artist(json_obj['artist'])
-    artists = _parse_artists(json_obj['artists'])
-    album = _parse_album(json_obj['album'], artist, artists)
-    kwargs = {
-        'id': json_obj['id'],
-        'name': json_obj['title'],
-        'duration': json_obj['duration'],
-        'track_num': json_obj['trackNumber'],
-        'disc_num': json_obj['volumeNumber'],
-        'popularity': json_obj['popularity'],
-        'artist': artist,
-        'artists': artists,
-        'album': album,
-        'available': bool(json_obj['streamReady']),
-    }
-    return Track(**kwargs)
+    def _parse_search(self, json_obj):
+        result = SearchResult()
+        if 'artists' in json_obj:
+            result.artists = [self._parse_artist(json) for json in json_obj['artists']['items']]
+        if 'albums' in json_obj:
+            result.albums = [self._parse_album(json) for json in json_obj['albums']['items']]
+        if 'tracks' in json_obj:
+            result.tracks = [self._parse_track(json) for json in json_obj['tracks']['items']]
+        if 'playlists' in json_obj:
+            result.playlists = [self._parse_playlist(json) for json in json_obj['playlists']['items']]
+        if 'videos' in json_obj:
+            result.videos = [self._parse_video(json) for json in json_obj['videos']['items']]
+        return result
 
-
-def _parse_genres(json_obj):
-    image = "http://resources.wimpmusic.com/images/%s/460x306.jpg" \
-            % json_obj['image'].replace('-', '/')
-    return Category(id=json_obj['path'], name=json_obj['name'], image=image)
-
-
-def _parse_moods(json_obj):
-    image = "http://resources.wimpmusic.com/images/%s/342x342.jpg" \
-            % json_obj['image'].replace('-', '/')
-    return Category(id=json_obj['path'], name=json_obj['name'], image=image)
-
+#------------------------------------------------------------------------------
+# Class to work with user favorites
+#------------------------------------------------------------------------------
 
 class Favorites(object):
+
+    ids_loaded = False
+    ids = {}
 
     def __init__(self, session, user_id):
         self._session = session
         self._base_url = 'users/%s/favorites' % user_id
+        self.reset()
+
+    def reset(self):
+        self.ids_loaded = False
+        self.ids = {'artists': [], 'albums': [], 'playlists': [], 'tracks': [], 'videos': []}
+
+    def load_all(self, force_reload=False):
+        if force_reload or not self.ids_loaded:
+            # Reset all first
+            self.ids = {'artists': [], 'albums': [], 'playlists': [], 'tracks': [], 'videos': []}
+            self.ids_loaded = False
+            r = self._session.request('GET', self._base_url + '/ids')
+            if r.ok:
+                json_obj = r.json()
+                if 'ARTIST' in json_obj:
+                    self.ids['artists'] = json_obj.get('ARTIST')
+                if 'ALBUM' in json_obj:
+                    self.ids['albums'] = json_obj.get('ALBUM')
+                if 'PLAYLIST' in json_obj:
+                    self.ids['playlists'] = json_obj.get('PLAYLIST')
+                if 'TRACK' in json_obj:
+                    self.ids['tracks'] = json_obj.get('TRACK')
+                if 'VIDEO' in json_obj:
+                    self.ids['videos'] = json_obj.get('VIDEO')
+                self.ids_loaded = True
+        return self.ids
+
+    def get(self, content_type, limit=9999):
+        items = self._session._map_request(self._base_url + '/%s' % content_type, params={'limit': limit if content_type <> 'videos' else min(limit, 100)}, ret=content_type)
+        self.ids[content_type] = ['%s' % item.id for item in items]
+        return items
+
+    def add(self, content_type, item_ids):
+        if isinstance(item_ids, basestring):
+            ids = [item_ids]
+        else:
+            ids = item_ids
+        param = {'artists': 'artistId', 'albums': 'albumId', 'playlists': 'uuid', 
+                 'tracks': 'trackIds', 'videos': 'videoIds'}.get(content_type)
+        ok = self._session.request('POST', self._base_url + '/%s' % content_type, data={param: ','.join(ids)}).ok
+        if ok and self.ids_loaded:
+            for _id in ids:
+                if _id not in self.ids[content_type]:
+                    self.ids[content_type].append(_id)
+        return ok
+
+    def remove(self, content_type, item_id):
+        ok = self._session.request('DELETE', self._base_url + '/%s/%s' % (content_type, item_id)).ok
+        if ok and self.ids_loaded and item_id in self.ids.get(content_type, []):
+            self.ids[content_type].remove(item_id)
+        return ok
 
     def add_artist(self, artist_id):
-        return self._session.request('POST', self._base_url + '/artists', data={'artistId': artist_id}).ok
-
-    def add_album(self, album_id):
-        return self._session.request('POST', self._base_url + '/albums', data={'albumId': album_id}).ok
-
-    def add_track(self, track_id):
-        return self._session.request('POST', self._base_url + '/tracks', data={'trackId': track_id}).ok
+        return self.add('artists', artist_id)
 
     def remove_artist(self, artist_id):
-        return self._session.request('DELETE', self._base_url + '/artists/%s' % artist_id).ok
+        return self.remove('artists', artist_id)
+
+    def add_album(self, album_id):
+        return self.add('albums', album_id)
 
     def remove_album(self, album_id):
-        return self._session.request('DELETE', self._base_url + '/albums/%s' % album_id).ok
+        return self.remove('albums', album_id)
+
+    def add_playlist(self, playlist_id):
+        return self.add('playlists', playlist_id)
+
+    def remove_playlist(self, playlist_id):
+        return self.remove('playlists', playlist_id)
+
+    def add_track(self, track_id):
+        return self.add('tracks', track_id)
 
     def remove_track(self, track_id):
-        return self._session.request('DELETE', self._base_url + '/tracks/%s' % track_id).ok
+        return self.remove('tracks', track_id)
+
+    def add_video(self, video_id):
+        return self.add('videos', video_id)
+
+    def remove_video(self, video_id):
+        return self.remove('videos', video_id)
 
     def artists(self):
-        return self._session._map_request(self._base_url + '/artists', ret='artists')
+        return self.get('artists')
+
+    def isFavoriteArtist(self, artist_id):
+        return '%s' % artist_id in self.ids.get('artists', [])
 
     def albums(self):
-        return self._session._map_request(self._base_url + '/albums', ret='albums')
+        return self.get('albums')
+
+    def isFavoriteAlbum(self, album_id):
+        return '%s' % album_id in self.ids.get('albums', [])
 
     def playlists(self):
-        return self._session._map_request(self._base_url + '/playlists', ret='playlists')
+        return self.get('playlists')
+
+    def isFavoritePlaylist(self, playlist_id):
+        return '%s' % playlist_id in self.ids.get('playlists', [])
 
     def tracks(self):
-        r = self._session.request('GET', self._base_url + '/tracks')
-        return [_parse_track(item['item']) for item in r.json()['items']]
+        return self.get('tracks')
 
+    def isFavoriteTrack(self, track_id):
+        return '%s' % track_id in self.ids.get('tracks', [])
+
+    def videos(self):
+        return self.get('videos', limit=100)
+
+    def isFavoriteVideo(self, video_id):
+        return '%s' % video_id in self.ids.get('videos', [])
+
+#------------------------------------------------------------------------------
+# Class to work with users playlists
+#------------------------------------------------------------------------------
 
 class User(object):
 
+    subscription = None
     favorites = None
 
-    def __init__(self, session, id):
-        """
-        :type session: :class:`Session`
-        :param id: The user ID
-        """
+    def __init__(self, session, user_id, subscription_type=SubscriptionType.hifi):
         self._session = session
-        self.id = id
-        self.favorites = Favorites(session, self.id)
+        self.id = user_id
+        self._base_url = 'users/%s' % user_id
+        self.favorites = Favorites(session, user_id)
+        self.subscription = Subscription(subscription = {'type': subscription_type})
 
-    def playlists(self):
-        return self._session.get_user_playlists(self.id)
+    def playlists(self, offset=0, limit=9999):
+        return self._session._map_request(self._base_url + '/playlists', params={'offset': offset, 'limit': limit}, ret='playlists')
+
+    def create_playlist(self, title, description=''):
+        return self._session._map_request(self._base_url + '/playlists', method='POST', data={'title': title, 'description': description}, ret='playlist')
+
+    def delete_playlist(self, playlist_id):
+        return self._session.request('DELETE', 'playlists/%s' % playlist_id).ok
+
+    def add_playlist_entries(self, playlist=None, item_ids=[]):
+        if not isinstance(playlist, Playlist):
+            playlist = self._session.get_playlist(playlist)
+        ok = False
+        trackIds = ','.join(item_ids)
+        if not playlist._etag:
+            # Read Playlist to get ETag
+            playlist = self._session.get_playlist(playlist.id)
+        if playlist and playlist._etag:
+            headers = {'If-None-Match': '%s' % playlist._etag}
+            data = {'trackIds': trackIds, 'toIndex': playlist.numberOfItems}
+            ok = self._session.request('POST', 'playlists/%s/tracks' % playlist.id, data=data, headers=headers).ok
+        else:
+            log.debug('Got no ETag for playlist %s' & playlist.title)
+        return ok
+
+    def remove_playlist_entry(self, playlist_id, entry_no=None, item_id=None):
+        if item_id:
+            # Got Track/Video-ID to remove from Playlist
+            entry_no = None
+            items = self._session.get_playlist_items(playlist_id)
+            for item in items:
+                if item.id == item_id:
+                    entry_no = item._user_playlist_tack_no
+            if entry_no == None:
+                return False
+        # Read Playlist to get ETag
+        playlist = self._session.get_playlist(playlist_id)
+        ok = False
+        if playlist and playlist._etag:
+            headers = {'If-None-Match': '%s' % playlist._etag}
+            ok = self._session.request('DELETE', 'playlists/%s/tracks/%s' % (playlist_id, entry_no), headers=headers).ok
+        return ok

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -86,6 +86,7 @@ class Album(BrowsableMedia):
     artists = []
     duration = -1
     numberOfTracks = 1
+    numberOfVideos = 0
     numberOfVolumes = 1
     allowStreaming = True
     streamReady = True

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -23,7 +23,6 @@ import datetime
 IMG_URL = 'http://resources.tidal.com/images/{picture}/{size}.jpg'
 ARTIST_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&artistid={artistid}'
 VIDEO_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&img={imagepath}'
-USER_PLAYLIST_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&uuid={uuid}&cols={cols}&rows={rows}&artimg'
 
 DEFAULT_ARTIST_IMG = '1e01cdb6-f15d-4d8b-8440-a047976c1cac'
 DEFAULT_ALBUM_IMG = '0dfd3368-3aa1-49a3-935f-10ffb39803c0'
@@ -202,16 +201,12 @@ class Playlist(BrowsableMedia):
 
     @property
     def image(self):
-        if self.type == 'USER':
-            return USER_PLAYLIST_IMAGE_URL.format(width=512, height=512, uuid=self.uuid, cols=3, rows=3)
         if self._image:
             return IMG_URL.format(picture=self._image.replace('-', '/'), size='320x214')
         return IMG_URL.format(picture=DEFAULT_PLAYLIST_IMG.replace('-', '/'), size='320x214')
 
     @property
     def fanart(self):
-        if self.type == 'USER':
-            return USER_PLAYLIST_IMAGE_URL.format(width=1080, height=720, uuid=self.uuid, cols=4, rows=3)
         if self._image:
             return IMG_URL.format(picture=self._image.replace('-', '/'), size='1080x720')
         return None

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -68,7 +68,7 @@ class BrowsableMedia(Model):
 
     # Internal Properties
     _isFavorite = False
-    _itemPosition = 0
+    _itemPosition = -1
     _offset = 0
     _totalNumberOfItems = 0
 
@@ -231,10 +231,10 @@ class PlayableMedia(BrowsableMedia):
 
     # Internal Properties
     _playlist_id = None        # ID of the Playlist
-    _playlist_pos = 0          # Item position in playlist
+    _playlist_pos = -1         # Item position in playlist
     _etag = None               # ETag for User Playlists
     _playlist_name = None      # Name of Playlist
-    _is_user_playlist = False  # Item of User Playlist ?
+    _playlist_type = ''        # Playlist Type
 
     def __init__(self):
         super(PlayableMedia, self).__init__()

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -15,78 +15,488 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 from __future__ import unicode_literals
-from enum import Enum
 
-IMG_URL = "http://images.osl.wimpmusic.com/im/im?w={width}&h={height}&{id_type}={id}"
+import re
+import datetime
+
+IMG_URL = 'http://resources.tidal.com/images/{picture}/{size}.jpg'
+ARTIST_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&artistid={artistid}'
+VIDEO_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&img={imagepath}'
+USER_PLAYLIST_IMAGE_URL = 'http://images.tidalhifi.com/im/im?w={width}&h={height}&uuid={uuid}&cols={cols}&rows={rows}&artimg'
+
+DEFAULT_ARTIST_IMG = '1e01cdb6-f15d-4d8b-8440-a047976c1cac'
+DEFAULT_ALBUM_IMG = '0dfd3368-3aa1-49a3-935f-10ffb39803c0'
+DEFAULT_PLAYLIST_IMG = '443331e2-0421-490c-8918-5a4867949589' 
+DEFAULT_VIDEO_IMB = 'fa6f0650-76ac-41d1-a4a3-7fe4c89fca90'
+
+CATEGORY_IMAGE_SIZES = {'genres': '460x306', 'moods': '342x342'}
+
+RE_ISO8601 = re.compile(r'^(?P<full>((?P<year>\d{4})([/-]?(?P<month>(0[1-9])|(1[012]))([/-]?(?P<day>(0[1-9])|([12]\d)|(3[01])))?)?(?:[\sT](?P<hour>([01][0-9])|(?:2[0123]))(\:?(?P<minute>[0-5][0-9])(\:?(?P<second>[0-5][0-9])(?P<ms>([\,\.]\d{1,10})?))?)?(?:Z|([\-+](?:([01][0-9])|(?:2[0123]))(\:?(?:[0-5][0-9]))?))?)?))$')
+
+
+class Quality(object):
+    lossless = 'LOSSLESS'
+    high = 'HIGH'
+    low = 'LOW'
+    trial = 'TRIAL' # 30 Seconds MP3 Stream
+
+
+class SubscriptionType(object):
+    premium = 'PREMIUM'
+    hifi = 'HIFI'
+    free = 'FREE'
 
 
 class Model(object):
     id = None
-    name = None
+    name = 'Unknown'
+
+    def parse_date(self, datestring):
+        try:
+            d = RE_ISO8601.match(datestring).groupdict()
+            if d['hour'] and d['minute'] and d['second']:
+                return datetime.datetime(year=int(d['year']), month=int(d['month']), day=int(d['day']), hour=int(d['hour']), minute=int(d['minute']), second=int(d['second']))
+            else:
+                return datetime.datetime(year=int(d['year']), month=int(d['month']), day=int(d['day']))
+        except:
+            pass
+        return None
+
+
+class BrowsableMedia(Model):
+
+    # Internal Properties
+    _isFavorite = False
+    _itemPosition = 0
+    _offset = 0
+    _totalNumberOfItems = 0
+
+    @property
+    def image(self):
+        return None
+
+    @property
+    def fanart(self):
+        return None
+
+
+class Album(BrowsableMedia):
+    title = 'Unknown'
+    artist = None
+    artists = []
+    duration = -1
+    numberOfTracks = 1
+    numberOfVolumes = 1
+    allowStreaming = True
+    streamReady = True
+    premiumStreamingOnly = False
+    streamStartDate = None
+    releaseDate = None
+    cover = None
+    type = 'ALBUM'
+    explicit = False
+    version = None
 
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
-
-
-class Album(Model):
-    artist = None
-    artists = []
-    num_tracks = -1
-    duration = -1
-    release_date = None
-
-    @property
-    def image(self, width=512, height=512):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='albumid')
-
-
-class Artist(Model):
-    role = None
+        super(Album, self).__init__()
+        if self.releaseDate:
+            self.releaseDate = self.parse_date(self.releaseDate)
+        if self.streamStartDate:
+            self.streamStartDate = self.parse_date(self.streamStartDate)
+        self.num_tracks = self.numberOfTracks # For Backward Compatibility
+        self.release_date = self.releaseDate  # For Backward Compatibility
+        self.name = self.title                # For Backward Compatibility
 
     @property
-    def image(self, width=512, height=512):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='artistid')
+    def year(self):
+        if self.releaseDate:
+            return self.releaseDate.year
+        if self.streamStartDate:
+            return self.streamStartDate.year
+        return None
+
+    @property
+    def image(self):
+        if self.cover:
+            return IMG_URL.format(picture=self.cover.replace('-', '/'), size='640x640')
+        return IMG_URL.format(picture=DEFAULT_ALBUM_IMG.replace('-', '/'), size='640x640')
+
+    @property
+    def fanart(self):
+        if self.artist and isinstance(self.artist, Artist):
+            return self.artist.fanart
+        if self.cover:
+            return IMG_URL.format(picture=self.cover.replace('-', '/'), size='1280x1280')
+        return None
 
 
-class Playlist(Model):
+class Artist(BrowsableMedia):
+    picture = None
+    url = None
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Artist, self).__init__()
+
+    @property
+    def image(self):
+        if self.picture:
+            return IMG_URL.format(picture=self.picture.replace('-', '/'), size='320x320')
+        return IMG_URL.format(picture=DEFAULT_ARTIST_IMG.replace('-', '/'), size='320x320')
+
+    @property
+    def fanart(self):
+        if self.picture:
+            return IMG_URL.format(picture=self.picture.replace('-', '/'), size='1080x720')
+        return ARTIST_IMAGE_URL.format(width=1080, height=720, artistid=self.id)
+
+
+class Playlist(BrowsableMedia):
     description = None
     creator = None
     type = None
-    is_public = None
+    uuid = None
+    title = 'Unknown'
     created = None
-    last_updated = None
-    num_tracks = -1
+    creationDate = None
+    publicPlaylist = None
+    lastUpdated = None
+    numberOfTracks = 0
+    numberOfVideos = 0
     duration = -1
+
+    # Internal Properties
+    _image = None  # For Backward Compatibility because "image" is a property method
+    _etag = None   # ETag from HTTP Response Header for Playlist Operations
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Playlist, self).__init__()
+        self.id = self.uuid
+        self.is_public = self.publicPlaylist # For Backward Compatibility
+        self.last_updated = self.lastUpdated # For Backward Compatibility
+        self.num_tracks = self.numberOfItems # For Backward Compatibility
+        self.name = self.title               # For Backward Compatibility
+        self._image = kwargs.get('image', None) # Because "image" is a property method
+        if self.created:
+            # New Property for Backward Compatibility
+            self.creationDate = self.parse_date(self.created)
+        if self.lastUpdated:
+            self.lastUpdated = self.parse_date(self.lastUpdated)
+        else:
+            self.lastUpdated = self.creationDate
 
     @property
-    def image(self, width=512, height=512):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='uuid')
+    def numberOfItems(self):
+        return self.numberOfTracks + self.numberOfVideos
+
+    @property
+    def year(self):
+        if self.lastUpdated:
+            return self.lastUpdated.year
+        elif self.creationDate:
+            return self.creationDate.year
+        return datetime.datetime.now().year
+
+    @property
+    def image(self):
+        if self.type == 'USER':
+            return USER_PLAYLIST_IMAGE_URL.format(width=512, height=512, uuid=self.uuid, cols=3, rows=3)
+        if self._image:
+            return IMG_URL.format(picture=self._image.replace('-', '/'), size='320x214')
+        return IMG_URL.format(picture=DEFAULT_PLAYLIST_IMG.replace('-', '/'), size='320x214')
+
+    @property
+    def fanart(self):
+        if self.type == 'USER':
+            return USER_PLAYLIST_IMAGE_URL.format(width=1080, height=720, uuid=self.uuid, cols=4, rows=3)
+        if self._image:
+            return IMG_URL.format(picture=self._image.replace('-', '/'), size='1080x720')
+        return None
 
 
-class Track(Model):
-    duration = -1
-    track_num = -1
-    disc_num = 1
-    popularity = -1
+class PlayableMedia(BrowsableMedia):
+    # Common Properties for Tacks and Videos
+    title = 'Unknown'
     artist = None
     artists = []
+    version = None
+    explicit = False
+    duration = 30
+    allowStreaming = True
+    streamReady = True
+    streamStartDate = None
+
+    # Internal Properties
+    _playlist_id = None        # ID of the Playlist
+    _playlist_pos = 0          # Item position in playlist
+    _etag = None               # ETag for User Playlists
+    _playlist_name = None      # Name of Playlist
+    _is_user_playlist = False  # Item of User Playlist ?
+
+    def __init__(self):
+        super(PlayableMedia, self).__init__()
+        if self.streamStartDate:
+            self.streamStartDate = self.parse_date(self.streamStartDate)
+        self.name = self.title  # For Backward Compatibility
+
+    @property
+    def year(self):
+        if self.streamStartDate:
+            return self.streamStartDate.year
+        return datetime.datetime.now().year
+
+    @property
+    def available(self):
+        return self.streamReady and self.allowStreaming
+
+
+class Track(PlayableMedia):
+    trackNumber = 1
+    volumeNumber = 1
     album = None
-    available = True
+    popularity = 0
+    isrc = None
+    premiumStreamingOnly = False
+    replayGain = 0.0
+    peak = 1.0
+
+    # Internal Properties
+    _ftArtists = []  # All artists except main (Filled by parser)
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Track, self).__init__()
+        self.track_num = self.trackNumber # For Backward Compatibility
+        self.disc_num =self.volumeNumber  # For Backward Compatibility
+        self.popularity = int("0%s" % self.popularity)
+
+    @property
+    def year(self):
+        if self.album and isinstance(self.album, Album) and getattr(self.album, 'year', None):
+            return self.album.year
+        return super(Track, self).year
+
+    @property
+    def image(self):
+        if self.album and isinstance(self.album, Album):
+            return self.album.image
+        return IMG_URL.format(picture=DEFAULT_ALBUM_IMG.cover.replace('-', '/'), size='640x640')
+
+    @property
+    def fanart(self):
+        if self.artist and isinstance(self.artist, Artist):
+            return self.artist.fanart
+        return None
+
+
+class Video(PlayableMedia):
+    releaseDate = None
+    quality = None
+    imageId = None
+    imagePath = None
+
+    # Internal Properties
+    _ftArtists = []  # All artists except main (Filled by parser)
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Video, self).__init__()
+        if self.releaseDate:
+            self.releaseDate = self.parse_date(self.releaseDate)
+
+    @property
+    def year(self):
+        if self.releaseDate:
+            return self.releaseDate.year
+        return super(Video, self).year
+
+    @property
+    def image(self):
+        if self.imageId:
+            return IMG_URL.format(picture=self.imageId.replace('-', '/'), size='320x214')
+        elif self.imagePath:
+            return VIDEO_IMAGE_URL.format(width=320, height=214, imagepath=self.imagePath)
+        return IMG_URL.format(picture=DEFAULT_VIDEO_IMB.replace('-', '/'), size='320x214')
+
+    @property
+    def fanart(self):
+        if self.artist and isinstance(self.artist, Artist):
+            return self.artist.fanart
+        elif self.imagePath:
+            return VIDEO_IMAGE_URL.format(width=320, height=214, imagepath=self.imagePath)
+        return None
+
+    def getFtArtistsText(self):
+        text = ''
+        for item in self._ftArtists:
+            if len(text) > 0:
+                text = text + ', '
+            text = text + item.name
+        if len(text) > 0:
+            text = 'ft. by ' + text
+        return text
+
+
+class Promotion(BrowsableMedia):
+    header = None
+    subHeader = None
+    shortHeader = None
+    shortSubHeader = None
+    standaloneHeader = None
+    group = None        # NEWS|DISCOVERY|RISING
+    created = None
+    text = None
+    imageId = None
+    imageURL = None
+    type = None         # PLAYLIST|ALBUM|VIDEO|EXTURL
+    artifactId = None
+    duration= 0
+
+    # Internal Properties
+    _artist = None       # filled by parser
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Promotion, self).__init__()
+        if self.created:
+            self.created = self.parse_date(self.created)
+        self.id = '%s' % self.artifactId
+        self.id = self.id.strip()
+        self.name = self.shortHeader
+
+    @property
+    def image(self):
+        if self.imageId:
+            return IMG_URL.format(picture=self.imageId.replace('-', '/'), size='550x400')
+        return self.imageURL
+
+    @property
+    def fanart(self):
+        if self.imageId:
+            return IMG_URL.format(picture=self.imageId.replace('-', '/'), size='550x400')
+        return self.imageURL
+
+
+class Category(BrowsableMedia):
+    path = None
+    hasAlbums = False
+    hasArtists = False
+    hasPlaylists = False
+    hasTracks = False
+    hasVideos = False
+
+    # Internal Properties
+    _image = None   # "image" is also a property
+    _group = ''
+
+    @staticmethod
+    def groups():
+        return ['featured', 'rising', 'discovery', 'genres', 'moods', 'movies', 'shows']
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Category, self).__init__()
+        self.id = self.path
+        self._image = kwargs.get('image', None) # Because "image" is a property
+
+    @property
+    def image(self):
+        if self._image:
+            return IMG_URL.format(picture=self._image.replace('-', '/'), size=CATEGORY_IMAGE_SIZES.get(self._group, '512x512'))
+        return None
+
+    @property
+    def fanart(self):
+        if self._image:
+            return IMG_URL.format(picture=self._image.replace('-', '/'), size=CATEGORY_IMAGE_SIZES.get(self._group, '512x512'))
+        return None
+
+    @property
+    def content_types(self):
+        types = []
+        if self.hasArtists:   types.append('artists')
+        if self.hasAlbums:    types.append('albums')
+        if self.hasPlaylists: types.append('playlists')
+        if self.hasTracks:    types.append('tracks')
+        if self.hasVideos:    types.append('videos')
+        return types
+
+
+class Role(object):
+    main = 'MAIN'
+    featured = 'FEATURED'
 
 
 class SearchResult(Model):
+    ''' List of Search Result Items '''
     artists = []
     albums = []
     tracks = []
     playlists = []
+    videos = []
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(SearchResult, self).__init__()
 
 
-class Category(Model):
-    image = None
+class UserInfo(Model):
+    username = ''
+    firstName = ''
+    lastName = ''
+    email = ''
+    created = None
+    picture = None
+    newsletter = False
+    gender = 'm'
+    dateOfBirth = None
+    facebookUid = '0'
+    subscription = None
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(UserInfo, self).__init__()
+        if self.created:
+            self.created = self.parse_date(self.created)
+        if self.dateOfBirth:
+            self.dateOfBirth = self.parse_date(self.dateOfBirth)
+        self.facebookUid = '%s' % self.facebookUid
+        self.name = self.username
 
 
-class Role(Enum):
-    main = 'MAIN'
-    featured = 'FEATURED'
+class Subscription(Model):
+    subscription = {'type': SubscriptionType.hifi}
+    status = 'ACTIVE'
+    validUntil = None
+    highestSoundQuality = None
+    premiumAccess = True
+    canGetTrial = False
+    paymentType = ''
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        super(Subscription, self).__init__()
+        if not self.highestSoundQuality:
+            # Determine highest sound quality with subscription type 
+            self.highestSoundQuality = {SubscriptionType.hifi: Quality.lossless, 
+                                        SubscriptionType.premium: Quality.high,
+                                        SubscriptionType.free: Quality.low}.get(self.type, Quality.high)
+        self.validUntil = self.parse_date(self.validUntil if self.validUntil else '2099-12-31')
+
+    @property
+    def type(self):
+        try:
+            return self.subscription.get('type', SubscriptionType.hifi)
+        except:
+            return SubscriptionType.hifi
+
+    @type.setter
+    def type(self, value):
+        self.subscription = {'type': value}
+
+    @property
+    def isValis(self):
+        return self.validUntil >= datetime.datetime.now()


### PR DESCRIPTION
Hi tamland,

This is my modified/extended Version of your tidalapi:
- New Login-Token kgsOOmYk3zShYrNP, which works for all Audio Qualities and Videos
- All Streams uses HTTP protocol with this Token, so it works with Kodi Krypton Beta2, which has no
  support for RTMP protocol at this time.
- Added Login-Parameter clientUniqueKey, because all Login-Tokens need this parameter
  to get a valid Session-ID. Only the Browser Token wdgaB1CilGA-S_s2 doesn't need it.
  (All other old tokens will also work with the clientUniqueKey parameter)
- The API uses the "Preview Mode" if no user is logged in.
  All functions (except User Playlists and Favorites) can be used without a Login-Session 
  and the Streams will play as 30 Seconds demo streams (mp3 audio, low resolution video)
- Added some new calls into test_api.py
- The API functions are bachward compatible to the old version.
- This version can replace the tidalapi in your Kodi TIDAL Addon and it will work
  without any other changes in your addon.

Regards
arnesongit
