### PR TITLE
Update lossless token

### DIFF
--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -44,7 +44,7 @@ class Config(object):
     def __init__(self, quality=Quality.high):
         self.quality = quality
         self.api_location = 'https://api.tidalhifi.com/v1/'
-        self.api_token = 'P5Xbeo5LFvESeDy6' if self.quality == \
+        self.api_token = 'BI218mwp9ERZ3PFI' if self.quality == \
             Quality.lossless else '4zx46pyr9o8qZNRw',
 
 


### PR DESCRIPTION
Update the lossless token. The old token no longer works; it results in:
```
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://api.tidalhifi.com/v1/login/username?token=P5Xbeo5LFvESeDy6
```