### PR TITLE
`releaseDate` can be null

### DIFF
--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -231,7 +231,7 @@ def _parse_album(json_obj, artist=None, artists=None):
         'artist': artist,
         'artists': artists,
     }
-    if 'releaseDate' in json_obj:
+    if 'releaseDate' in json_obj and json_obj['releaseDate'] is not None:
         try:
             kwargs['release_date'] = datetime.datetime(*map(int, json_obj['releaseDate'].split('-')))
         except ValueError:


### PR DESCRIPTION
Walking the mood playlists can result in `_parse_album()` getting called with a null `releaseDate` in the JSON object. Add a simple sanity check to ensure we don't try to `split()` on `None`.