### PR TITLE
Add missing release url in Album model

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -69,6 +69,7 @@ def test_get_album(session):
     assert album.name == 'Some Things'
     assert album.num_tracks == 22
     assert album.num_discs == 2
+    assert album.url == 'http://www.tidal.com/album/17927863'
     assert album.duration == 6704
     assert album.artist.name == 'Lasgo'
     assert album.artists[0].name == 'Lasgo'

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -289,6 +289,7 @@ def _parse_album(json_obj, artist=None, artists=None):
     kwargs = {
         'id': json_obj['id'],
         'name': json_obj['title'],
+        'url': json_obj.get('url'),
         'num_tracks': json_obj.get('numberOfTracks'),
         'num_discs': json_obj.get('numberOfVolumes'),
         'duration': json_obj.get('duration'),


### PR DESCRIPTION
Hi, after updating the package in my project, I get an error.
```
-- Getting 139306865...
Traceback (most recent call last):
  File "C:\Users\user\tidal.py", line 187, in <module>
    main()
  File "C:\Users\user\tidal.py", line 159, in main
    if not t.save_album(album):
  File "lib\td\ripper.py", line 81, in save_album
    self.Album = self.album(id)
  File "lib\td\tidal.py", line 44, in album
    url=album.url,
AttributeError: 'Album' object has no attribute 'url'
```