### PR TITLE
Increase limit for user.favorites.tracks

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+v0.6.7
+------
+
+* Able to change limit param for base request - dmitry-ee
+* Change user.favorites.tracks() limit to 5000 - dmitry-ee
+
 v0.6.6
 ------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2014-2019, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.6'
+release = '0.6.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('HISTORY.rst') as f:
 
 setup(
     name='tidalapi',
-    version='0.6.6',
+    version='0.6.7',
     description='Unofficial API for TIDAL music streaming service.',
     long_description=long_description,
     author='Thomas Amland',

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -306,6 +306,7 @@ def _parse_album(json_obj, artist=None, artists=None):
         'duration': json_obj.get('duration'),
         'artist': artist,
         'artists': artists,
+        'cover': json_obj.get('cover'),
     }
     if 'releaseDate' in json_obj and json_obj['releaseDate'] is not None:
         try:

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -110,11 +110,11 @@ class Session(object):
         url = urljoin(self._config.api_location, 'users/%s/subscription' % self.user.id)
         return requests.get(url, params={'sessionId': self.session_id}).ok
 
-    def request(self, method, path, params=None, data=None):
+    def request(self, method, path, params=None, data=None, limit=999):
         request_params = {
             'sessionId': self.session_id,
             'countryCode': self.country_code,
-            'limit': '999',
+            'limit': limit,
         }
         if params:
             request_params.update(params)
@@ -410,7 +410,7 @@ class Favorites(object):
         return self._session._map_request(self._base_url + '/playlists', ret='playlists')
 
     def tracks(self):
-        request = self._session.request('GET', self._base_url + '/tracks')
+        request = self._session.request('GET', self._base_url + '/tracks', limit=5000)
         return [_parse_media(item['item']) for item in request.json()['items']]
 
 

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -34,6 +34,7 @@ class Model(object):
 class Album(Model):
     artist = None
     artists = []
+    cover = None
     num_tracks = -1
     duration = -1
     release_date = None
@@ -53,7 +54,8 @@ class Album(Model):
 
         Original sizes: 80x80, 160x160, 320x320, 640x640 and 1280x1280
         """
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='albumid')
+        return "https://resources.tidal.com/images/%s/%ix%i.jpg" % (self.cover.replace('-', '/'), width, height)
+        # return IMG_URL.format(width=width, height=height, id=self.id, id_type='albumid')
 
 
 class Artist(Model):


### PR DESCRIPTION
I've encountered problem when was working on favorites library export.
`user.favorites.tracks()` method returned only 999 tracks instead of maximal possible amount (5000+).
So i made quiet simple workaround fix for that.
Hope it looks good