### PR TITLE
0.7.x Rewrite Issues

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -28,6 +28,7 @@ def test_load_session(session):
     session = tidalapi.Session()
     assert session.load_session(session_id)
     assert session.check_login()
+    assert isinstance(session.user, tidalapi.LoggedInUser)
     assert session.load_session(session_id + "f") is False
 
 

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -59,13 +59,13 @@ class Album(object):
 
     def parse(self, json_obj, artist=None, artists=None):
         if artists is None:
-            artists = self.artist.parse_artists(json_obj['artists'])
+            artists = self.session.parse_artists(json_obj['artists'])
 
         # Sometimes the artist field is not filled, an example is 140196345
         if not 'artist' in json_obj:
             artist = artists[0]
         elif artist is None:
-            artist = self.artist.parse_artist(json_obj['artist'])
+            artist = self.session.parse_artist(json_obj['artist'])
 
         self.id = json_obj['id']
         self.name = json_obj['title']

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -167,7 +167,7 @@ class Session(object):
             user_id = request['userId']
 
         self.country_code = country_code
-        self.user = tidalapi.User(self, user_id=user_id)
+        self.user = tidalapi.User(self, user_id=user_id).factory()
         return True
 
     def _invert_alac(self):


### PR DESCRIPTION
I encountered two issues in the 0.7.x rewrite:
1. A call of User.factory() is missing in load_session()
2. A deep (instead of a shallow) copy of the Album object is required in Album.parse() 