### PR TITLE
fix for exception when self.img_uuid is None

### DIFF
--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -31,43 +31,7 @@ class Model(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
-
-class Album(Model):
-    artist = None
-    artists = []
-    num_tracks = -1
-    duration = -1
-    release_date = None
-
-    @property
-    def image(self, width=1280, height=1280):
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
-
-    def picture(self, width, height):
-        """
-        A url to an album picture
-
-        :param width: pixel width, maximum 2000
-        :type width: int
-        :param height: pixel height, maximum 2000
-        :type height: int
-
-        Accepted sizes: 80x80, 160x160, 320x320, 640x640 and 1280x1280
-        """
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
-
-
-class Artist(Model):
-    roles = []
-    role = None
-
-    @property
-    def image(self, width=750, height=750):
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
-
+class ImageModel(object):
     def picture(self, width, height):
         """
         A url to an artist picture
@@ -79,11 +43,31 @@ class Artist(Model):
 
         Accepted sizes: 80x80, 160x160, 320x320, 480x480, 750x750
         """
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
+        if self.img_uuid is not None:
+            uuid = self.img_uuid.replace('-', '/')
+            return IMG_URL.format(uuid=uuid, width=width, height=height)
+
+class Album(Model, ImageModel):
+    artist = None
+    artists = []
+    num_tracks = -1
+    duration = -1
+    release_date = None
+
+    @property
+    def image(self, width=1280, height=1280):
+        return self.picture(width, height)
 
 
-class Playlist(Model):
+class Artist(Model, ImageModel):
+    roles = []
+    role = None
+
+    @property
+    def image(self, width=750, height=750):
+        return self.picture(width, height)
+
+class Playlist(Model, ImageModel):
     description = None
     creator = None
     type = None
@@ -95,24 +79,7 @@ class Playlist(Model):
 
     @property
     def image(self, width=1080, height=1080):
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
-
-    def picture(self, width, height):
-        """
-        A url to a playlist picture
-
-        :param width: pixel width, maximum 1080
-        :type width: int
-        :param height: pixel height, maximum 1080
-        :type height: int
-
-        Accepted sizes: 160x160, 320x320, 480x480, 640x640, 750x750, 1080x1080
-
-        """
-        uuid = self.img_uuid.replace('-', '/')
-        return IMG_URL.format(uuid=uuid, width=width, height=height)
-
+        return self.picture(width, height)
 
 class Media(Model):
     duration = -1


### PR DESCRIPTION
Using Mopidy with the mopidy-tidal backend, I'd often see log entries like this:

```
Feb  9 22:46:13 controller mopidy[9989]: Traceback (most recent call last):
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/lib/python3/dist-packages/mopidy/core/library.py", line 17, in _backend_error_handling
Feb  9 22:46:13 controller mopidy[9989]:     yield
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/lib/python3/dist-packages/mopidy/core/library.py", line 181, in get_images
Feb  9 22:46:13 controller mopidy[9989]:     if future.get() is None:
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/local/lib/python3.7/dist-packages/pykka/_threading.py", line 45, in get
Feb  9 22:46:13 controller mopidy[9989]:     _compat.reraise(*self._data['exc_info'])
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/local/lib/python3.7/dist-packages/pykka/_compat/__init__.py", line 29, in reraise
Feb  9 22:46:13 controller mopidy[9989]:     raise value
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/local/lib/python3.7/dist-packages/pykka/_actor.py", line 193, in _actor_loop
Feb  9 22:46:13 controller mopidy[9989]:     response = self._handle_receive(envelope.message)
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/local/lib/python3.7/dist-packages/pykka/_actor.py", line 299, in _handle_receive
Feb  9 22:46:13 controller mopidy[9989]:     return callee(*message.args, **message.kwargs)
Feb  9 22:46:13 controller mopidy[9989]:   File "/home/pi/workspaces/mopidy-tidal/mopidy_tidal/library.py", line 154, in get_images
Feb  9 22:46:13 controller mopidy[9989]:   File "/usr/local/lib/python3.7/dist-packages/tidalapi/models.py", line 68, in image
Feb  9 22:46:13 controller mopidy[9989]:     uuid = self.img_uuid.replace('-', '/')
Feb  9 22:46:13 controller mopidy[9989]: AttributeError: 'NoneType' object has no attribute 'replace'
```