### PR TITLE
Add option to fetch full album information for tracks

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -57,6 +57,15 @@ def test_track_url(session):
     assert 'audio.tidal.com' in track.get_url()
 
 
+def test_track_with_album(session):
+    track_id = 142278122
+    track = session.track(track_id)
+    print(track.album)
+    assert track.album.duration is None
+    track = session.track(track_id, True)
+    assert track.album.duration == 221
+
+
 def test_video(session):
     video = session.video(125506698)
 

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -484,16 +484,23 @@ class Session(object):
 
         return tidalapi.Playlist(session=self, playlist_id=playlist_id).factory()
 
-    def track(self, track_id=None):
+    def track(self, track_id=None, with_album=False):
         """
         Function to create a Track object with access to the session instance in a smoother way.
         Calls :class:`tidalapi.Track(session=session, track_id=track_id) <.Track>` internally
 
         :param track_id: (Optional) The TIDAL id of the Track. You may want access to the methods without an id.
+        :param with_album: (Optional) Whether to fetch the complete :class:`.Album` for the track or not
         :return: Returns a :class:`.Track` object that has access to the session instance used.
         """
 
-        return tidalapi.Track(session=self, media_id=track_id)
+        item = tidalapi.Track(session=self, media_id=track_id)
+        if item.album and with_album:
+            album = self.album(item.album.id)
+            if album:
+                item.album = album
+
+        return item
 
     def video(self, video_id=None):
         """


### PR DESCRIPTION
Tidal does not return full album json for track response, which can lead to missing values for release date for example.

Taken from https://github.com/JuniorJPDJ/python-tidal/blob/master/tidalapi/__init__.py#L344