### PR TITLE
Add option to return a fallback image if cover not exists

### DIFF
--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -20,6 +20,7 @@ import datetime
 import pytest
 from dateutil import tz
 
+import tidalapi
 from .cover import verify_image_cover, verify_video_cover
 
 
@@ -90,3 +91,9 @@ def test_no_release_date(session):
     assert album.release_date is None
     assert album.tidal_release_date
     assert album.available_release_date == datetime.datetime(year=2021, month=3, day=9, tzinfo=tz.tzutc())
+
+
+def test_no_cover(session):
+    album = session.album(82804683)
+    assert album.cover is None
+    assert album.image(1280) == tidalapi.album.DEFAULT_ALBUM_IMAGE

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -19,6 +19,8 @@
 import copy
 import dateutil.parser
 
+DEFAULT_ALBUM_IMAGE = "https://tidal.com/browse/assets/images/defaultImages/defaultAlbumImage.png"
+
 
 class Album(object):
     """
@@ -141,7 +143,7 @@ class Album(object):
         params = {'offset': offset, 'limit': limit}
         return self.requests.map_request('albums/%s/items' % self.id, params=params, parse=self.session.parse_media)
 
-    def image(self, dimensions):
+    def image(self, dimensions, default=DEFAULT_ALBUM_IMAGE):
         """
         A url to an album image cover
 
@@ -151,6 +153,9 @@ class Album(object):
 
         Valid resolutions: 80x80, 160x160, 320x320, 640x640, 1280x1280
         """
+        if not self.cover:
+            return default
+
         if dimensions not in [80, 160, 320, 640, 1280]:
             raise ValueError("Invalid resolution {0} x {0}".format(dimensions))
 


### PR DESCRIPTION
Some rare albums on Tidal seem to have no cover art.

Example: https://tidal.com/album/82804683