### PR TITLE
Remove obsolete parameter session_id from load_oauth_session(...)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[cod]
+__pycache__
 
 # C extensions
 *.so
@@ -46,6 +47,7 @@ output/*/index.html
 docs/_build
 
 # Visual Studio
+.vscode
 .vs
 *.sln
 *.pyproj

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,11 +33,11 @@ def session(request):
 
 
 def login(request):
-    access_token, refresh_token, session_id, token_type = get_credentials()
+    access_token, refresh_token, expiry_time, token_type = get_credentials()
     config = tidalapi.Config(quality=tidalapi.Quality.master)
     tidal_session = tidalapi.Session(config)
 
-    if access_token and tidal_session.load_oauth_session(session_id, token_type, access_token, refresh_token):
+    if access_token and tidal_session.load_oauth_session(token_type, access_token, refresh_token, expiry_time):
         return tidal_session
 
     else:
@@ -45,8 +45,8 @@ def login(request):
         info = [
             tidal_session.access_token,
             tidal_session.refresh_token,
-            tidal_session.session_id,
-            tidal_session.token_type
+            tidal_session.token_type,
+            tidal_session.expiry_time
         ]
         if not isinstance(keyring.get_keyring(), keyring.backends.fail.Keyring):
             keyring.set_password('TIDAL Access Token', tidal_session.user.email, ':'.join(info))
@@ -81,9 +81,9 @@ def get_credentials():
     info = info.split(':')
     access_key = info[0]
     refresh_key = info[1]
-    session_id = info[2]
+    expiry_time = info[2]
     token_type = info[3]
-    return access_key, refresh_key, session_id, token_type
+    return access_key, refresh_key, expiry_time, token_type
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -25,14 +25,13 @@ from tidalapi import Artist, Album, Playlist, Track, Video
 
 
 def test_load_oauth_session(session):
-    session_id = session.session_id
     token_type = session.token_type
     access_token = session.access_token
+    expiry_time = session.expiry_time
     session = tidalapi.Session()
-    assert session.load_oauth_session(session_id, token_type, access_token)
+    assert session.load_oauth_session(token_type, access_token, expiry_time)
     assert session.check_login()
     assert isinstance(session.user, tidalapi.LoggedInUser)
-    assert session.load_oauth_session(session_id + "f", token_type, access_token) is False
 
 
 def test_failed_login():

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -256,32 +256,28 @@ class Session(object):
         self.user = tidalapi.User(self, user_id=user_id).factory()
         return True
 
-    def load_oauth_session(self, session_id, token_type, access_token, refresh_token=None):
+    def load_oauth_session(self, token_type, access_token, refresh_token=None, expiry_time=None):
         """
         Login to TIDAL using details from a previous OAuth login, automatically
         refreshes expired access tokens if refresh_token is supplied as well.
 
         :param token_type: The type of token, e.g. Bearer
-        :param session_id: The TIDAL session id, has to be a UUID
         :param access_token: The access token received from an oauth login or refresh
         :param refresh_token: (Optional) A refresh token that lets you get a new access token after it has expired
+        :param expiry_time: (Optional) The datetime the access token will expire
         :return: True if we believe the log in was successful, otherwise false.
         """
-        try:
-            uuid.UUID(session_id)
-        except ValueError:
-            log.error("Session id did not have a valid UUID format")
-            return False
-        self.session_id = session_id
         self.token_type = token_type
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self.expiry_time = expiry_time
 
-        request = self.request.basic_request('GET', 'sessions')
+        request = self.request.request('GET', 'sessions')
         json = request.json()
         if not request.ok:
             return False
 
+        self.session_id = json['sessionId']
         self.country_code = json['countryCode']
         self.user = tidalapi.User(self, user_id=json['userId']).factory()
 


### PR DESCRIPTION
The session_id parameter in load_oauth_session seems to be obsolete and can be removed. The session_id can as well be retrieved from the response to request('GET', 'sessions').