### PR TITLE
Add album release year property to model class

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,8 @@ extensions = [
     'sphinx.ext.doctest'
 ]
 
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+
 autodoc_member_order = 'bysource'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -18,6 +18,8 @@
 
 import datetime
 import pytest
+from dateutil import tz
+
 from .cover import verify_image_cover, verify_video_cover
 
 
@@ -81,3 +83,10 @@ def test_image_cover(session):
 
 def test_video_cover(session):
     verify_video_cover(session.album(108043414), [80, 160, 320, 640, 1280])
+
+
+def test_no_release_date(session):
+    album = session.album(174114082)
+    assert album.release_date is None
+    assert album.tidal_release_date
+    assert album.available_release_date == datetime.datetime(year=2021, month=3, day=9, tzinfo=tz.tzutc())

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -98,6 +98,28 @@ class Album(object):
 
         return copy.copy(self)
 
+    @property
+    def year(self):
+        """
+        Convenience function to get the year using :class:`available_release_date`
+
+        :return: An :any:`python:int` containing the year the track was released
+        """
+        return self.available_release_date.year if self.available_release_date else None
+
+    @property
+    def available_release_date(self):
+        """
+        Get the release date if it's available, otherwise get the day it was released on TIDAL
+
+        :return: A :any:`python:datetime.datetime` object with the release date, or the tidal release date, can be None
+        """
+        if self.release_date:
+            return self.release_date
+        if self.tidal_release_date:
+            return self.tidal_release_date
+        return None
+
     def tracks(self, limit=None, offset=0):
         """
         Returns the tracks in classes album.


### PR DESCRIPTION
Another helpful feature that could save some crashes, as some albums on Tidal don't have a release date for some reason.

Example album: https://tidal.com/browse/album/174114082