### PR TITLE
Use oauth for username + pass login

### DIFF
--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -343,6 +343,7 @@ class Session(object):
 
         session.close()
         log.info("Link Login Successful")
+        future.result()  # Wait for future to finish.
         return True
 
     def login_oauth_simple(self, function=print):


### PR DESCRIPTION
Fixes #84 
Rewrote the Username, Password login to use the new OAuth API. This is essentially the OAuth link login, but will complete the rest of the login flow automatically, without user interaction.