### PR TITLE
Retrieve all items / pagination support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+v0.6.7
+------
+
+* Fix wimp images not resolving - ktnrg45_
+* Made the favorite playlists function also return created playlists - morguldir_
+
 v0.6.6
 ------
 
@@ -37,3 +43,4 @@ v0.6.2
 
 .. _morguldir: https://github.com/morguldir
 .. _Husky22: https://github.com/Husky22
+.. _ktnrg45: https://github.com/ktnrg45

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+v0.6.10
+-------
+ * Update the client secret - 1nikolas_
+ * Use a track url endpoint compatible with the new secret - morguldir_
+
 v0.6.9
 ------
 
@@ -57,3 +62,4 @@ v0.6.2
 .. _morguldir: https://github.com/morguldir
 .. _Husky22: https://github.com/Husky22
 .. _ktnrg45: https://github.com/ktnrg45
+.. _1nikolas: https://github.com/1nikolas

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 -------
 
+v0.6.8
+------
+
+* Support OAuth login through login_oauth_simple() and login_oauth() - morguldir_
+* Support loading an OAuth session through load_oauth_session() - morguldir_
+* Include more info when a request fails - morguldir_
+
 v0.6.7
 ------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+v0.6.9
+------
+
+* Update the client secret - morguldir_
+* Fix token_refresh() not correctly including the client secret - morguldir_
+
 v0.6.8
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ tidalapi
     :target: https://pypi.org/project/tidalapi
 
 .. image:: https://api.netlify.com/api/v1/badges/f05c0752-4565-4940-90df-d2b3fe91c84b/deploy-status
-    :target: https://tidalapi.netlify.com/
+    :target: https://0-6-x--tidalapi.netlify.app/
 
 Unofficial Python API for TIDAL music streaming service.
 
@@ -35,7 +35,8 @@ Example usage
     import tidalapi
 
     session = tidalapi.Session()
-    session.login('username', 'password')
+    # Will run until you visit the printed url and link your account
+    session.login_oauth_simple()
     tracks = session.get_album_tracks(album_id=16909093)
     for track in tracks:
         print(track.name)
@@ -44,4 +45,4 @@ Example usage
 Documentation
 -------------
 
-Documentation is available at https://tidalapi.netlify.com
+Documentation is available at https://0-6-x--tidalapi.netlify.app/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2014-2019, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.6'
+release = '0.6.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # -- Project information -----------------------------------------------------
 
 project = 'tidalapi'
-copyright = '2014-2019, Thomas Amland, morguldir'
+copyright = '2014-2021, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2014-2021, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.8'
+release = '0.6.9'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2014-2021, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.9'
+release = '0.6.10'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2014-2021, Thomas Amland, morguldir'
 author = 'Thomas Amland, morguldir'
 
 # The full version, including alpha/beta/rc tags
-release = '0.6.7'
+release = '0.6.8'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx>=1.8.5
+futures

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('HISTORY.rst') as f:
 
 setup(
     name='tidalapi',
-    version='0.6.9',
+    version='0.6.10',
     description='Unofficial API for TIDAL music streaming service.',
     long_description=long_description,
     author='Thomas Amland',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('HISTORY.rst') as f:
 
 setup(
     name='tidalapi',
-    version='0.6.6',
+    version='0.6.7',
     description='Unofficial API for TIDAL music streaming service.',
     long_description=long_description,
     author='Thomas Amland',
@@ -37,9 +37,9 @@ setup(
         "Programming Language :: Python :: 2",
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('HISTORY.rst') as f:
 
 setup(
     name='tidalapi',
-    version='0.6.8',
+    version='0.6.9',
     description='Unofficial API for TIDAL music streaming service.',
     long_description=long_description,
     author='Thomas Amland',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ required = ['requests']
 if sys.version_info < (3,4):
     required.append('enum34')
 
+if sys.version_info < (3,0):
+    required.append('futures')
+
 long_description = ""
 with open('README.rst') as f:
     long_description += f.read()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open('HISTORY.rst') as f:
 
 setup(
     name='tidalapi',
-    version='0.6.7',
+    version='0.6.8',
     description='Unofficial API for TIDAL music streaming service.',
     long_description=long_description,
     author='Thomas Amland',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,7 +94,7 @@ def test_get_album_videos(session):
     videos = session.get_album_videos(108046179)
     assert videos[0].name == 'Formation (Choreography Version)'
     assert videos[0].track_num == 14
-    assert videos[0].duration == 262
+    assert videos[0].duration == 261
     assert videos[0].artist.name == 'Beyoncé'
     assert videos[0].album.name == 'Lemonade'
     assert videos[1].name == 'Lemonade Film'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,7 @@ def test_get_artist(session):
 
 def test_get_artist_albums(session):
     albums = session.get_artist_albums(16147)
-    assert albums[0].name == 'Some Things'
+    assert albums[0].name == 'Some Things (Deluxe)'
 
 
 def test_get_artist_albums_ep_single(session):
@@ -69,7 +69,7 @@ def test_get_album(session):
     album_id = 17927863
     album = session.get_album(album_id)
     assert album.id == album_id
-    assert album.name == 'Some Things'
+    assert album.name == 'Some Things (Deluxe)'
     assert album.num_tracks == 22
     assert album.num_discs == 2
     assert album.duration == 6704

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 morguldir
+# Copyright (C) 2019-2021 morguldir
 # Copyright (C) 2014 Thomas Amland
 #
 # This program is free software: you can redistribute it and/or modify

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,7 +96,7 @@ def test_get_album_videos(session):
     assert videos[0].album.name == 'Lemonade'
     assert videos[1].name == 'Lemonade Film'
     assert videos[1].track_num == 15
-    assert videos[1].duration == 3955
+    assert videos[1].duration == 3951
 
 
 def test_get_album_items(session):
@@ -108,7 +108,7 @@ def test_get_album_items(session):
     assert items[0].album.name == 'Lemonade'
     assert items[-1].name == 'Lemonade Film'
     assert items[-1].track_num == 15
-    assert items[-1].duration == 3955
+    assert items[-1].duration == 3951
     assert items[-1].type == 'Music Video'
 
 
@@ -125,8 +125,8 @@ def test_search(session):
 
 def test_artist_picture(session):
     artist = session.get_artist(16147)
-    assert requests.get(artist.picture(640,640)).status_code == 200
-    assert requests.get(tidalapi.models.Artist.image.fget(artist, 640, 640)).status_code == 200
+    assert requests.get(artist.picture(750,750)).status_code == 200
+    assert requests.get(tidalapi.models.Artist.image.fget(artist, 750, 750)).status_code == 200
 
 
 def test_album_picture(session):

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -121,7 +121,9 @@ class Session(object):
         url = urljoin(self._config.api_location, path)
         request = requests.request(method, url, params=request_params, data=data)
         log.debug("request: %s", request.request.url)
-        request.raise_for_status()
+        if not request.ok:
+            print(request.text)
+            request.raise_for_status()
         if request.content:
             log.debug("response: %s", json.dumps(request.json(), indent=4))
         return request

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -407,7 +407,15 @@ class Favorites(object):
         return self._session._map_request(self._base_url + '/albums', ret='albums')
 
     def playlists(self):
-        return self._session._map_request(self._base_url + '/playlists', ret='playlists')
+        favorites = self._session._map_request(self._base_url + '/playlists', ret='playlists')
+        created_playlists = self._session.get_user_playlists(self._session.user.id)
+
+        # Don't append duplicates to the return value
+        for playlist in created_playlists:
+            if not any(playlist.id == favorite.id for favorite in favorites):
+                favorites.append(playlist)
+
+        return favorites
 
     def tracks(self):
         request = self._session.request('GET', self._base_url + '/tracks')

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -465,9 +465,13 @@ class Session(object):
         return items
 
     def get_media_url(self, track_id):
-        params = {'soundQuality': self._config.quality}
-        r = self.request('GET', 'tracks/%s/streamUrl' % track_id, params)
-        return r.json()['url']
+        params = {
+            'urlusagemode': 'STREAM',
+            'audioquality': self._config.quality,
+            'assetpresentation': 'FULL'
+        }
+        request = self.request('GET', 'tracks/%s/urlpostpaywall' % track_id, params)
+        return request.json()['urls'][0]
 
     def get_track_url(self, track_id):
         return self.get_media_url(track_id)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -16,15 +16,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 from __future__ import unicode_literals
 from collections import namedtuple
 from enum import Enum
 
+import concurrent.futures
 import datetime
 import json
 import logging
 import requests
 import base64
+import time
+import uuid
 from .models import Artist, Album, Track, Video, Playlist, SearchResult, Category, Role
 
 try:
@@ -47,6 +51,26 @@ class VideoQuality(Enum):
     low = 'LOW'
 
 
+class LinkLogin(object):
+    """
+    The data required for logging in to TIDAL using a remote link, json is the data returned from TIDAL
+    """
+    #: Amount of seconds until the code expires
+    expires_in = None
+    #: The code the user should enter at the uri
+    user_code = None
+    #: The link the user has to visit
+    verification_uri = None
+    #: The link the user has to visit, with the code already included
+    verification_uri_complete = None
+
+    def __init__(self, json):
+        self.expires_in = json['expiresIn']
+        self.user_code = json['userCode']
+        self.verification_uri = json['verificationUri']
+        self.verification_uri_complete = json['verificationUriComplete']
+
+
 class Config(object):
     def __init__(self, quality=Quality.high, video_quality=VideoQuality.high):
         self.quality = quality.value
@@ -62,15 +86,57 @@ class Config(object):
             decode("".join(map(chr, [117, 116, 70, 95, 56]))))
         token = self.api_token
         self.api_token = list((base64.b64decode("d3RjaThkamFfbHlhQnBKaWQuMkMwb3puT2ZtaXhnMA==").decode()))
-        for B in token:
-            self.api_token.remove(B)
+        tok = "".join(([chr(ord(x)+1) for x in token[-6:]]))
+        token2 = token
+        token = token[:9]
+        token += tok
+        tok2 = "".join(([chr(ord(x)+2) for x in token[:-7]]))
+        token = token[8:]
+        token = tok2 + token
+        self.api_token = list((base64.b64decode("UHZ6a2RmMGNFbnhjTnJWa0gua0R5cFpvTGdpalloTg==").decode()))
+        for word in token:
+            self.api_token.remove(word)
         self.api_token = "".join(self.api_token)
+        string = ""
+        save = False
+        if not isinstance(token2, str):
+            save = True
+            string = "".encode('ISO-8859-1')
+            token2 = token2.encode('ISO-8859-1')
+        tok = string.join(([chr(ord(x) + 20) for x in token2[:-7]]))
+        token2 = token2[8:]
+        token2 = tok + token2
+        tok2 = string.join(([chr(ord(x)+22) for x in token2[-6:]]))
+        token2 = token2[:9]
+        token2 += tok2
+        self.client_id = list((base64.b64decode("V4g3fVh4NnVVgHZ1QoRhfWgub1krhViET3xpfzF9TVVl"
+                                                "Q1g2ZXd2MnpUZFNPVjNZN3FDM3AzNjc1ST0=").decode('ISO-8859-1')))
+        if save:
+            token2.decode('ISO-8859-1').encode('utf-16')
+            self.client_id = [x.encode('ISO-8859-1') for x in self.client_id]
+        for word in token2:
+            self.client_id.remove(word)
+        self.client_id = "".join(self.client_id)
+        self.client_secret = self.client_id
+        self.client_id = self.api_token
+
 
 class Session(object):
+    #: The TIDAL access token, this is what you use with load_oauth_session
+    access_token = None
+    #: A :class:`datetime` object containing the date the access token will expire
+    expiry_time = None
+    #: A refresh token for retrieving a new access token through refresh_token
+    refresh_token = None
+    #: The type of access token, e.g. Bearer
+    token_type = None
+    #: The id for a TIDAL session, you also need this to use load_oauth_session
+    session_id = None
+    country_code = None
+    #: A :class:`.User` object containing the currently logged in user.
+    user = None
+
     def __init__(self, config=Config()):
-        self.session_id = None
-        self.country_code = None
-        self.user = None
         self._config = config
         """:type _config: :class:`Config`"""
 
@@ -83,6 +149,40 @@ class Session(object):
 
         self.country_code = country_code
         self.user = User(self, id=user_id)
+
+    def load_oauth_session(self, session_id, token_type, access_token, refresh_token=None):
+        """
+        Login to TIDAL using details from a previous OAuth login, automatically
+        refreshes expired access tokens if refresh_token is supplied as well.
+
+        :param token_type: The type of token, e.g. Bearer
+        :param session_id: The TIDAL session id, has to be a UUID
+        :param access_token: The access token received from an oauth login or refresh
+        :param refresh_token: (Optional) A refresh token that lets you get a new access token after it has expired
+        :return: True if we believe the log in was successful, otherwise false.
+        """
+        try:
+            uuid.UUID(session_id)
+        except ValueError:
+            log.error("Session id did not have a valid UUID format")
+            return False
+        self.session_id = session_id
+        self.token_type = token_type
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+        request = self.basic_request('GET', 'sessions')
+        json = request.json()
+        if not request.ok and json['userMessage'].startswith("The token has expired.") and refresh_token:
+            log.debug("The access token has expired, trying to refresh it.")
+            refreshed = self.token_refresh(refresh_token)
+            if not refreshed:
+                return False
+
+        self.country_code = json['countryCode']
+        self.user = User(self, id=json['userId'])
+
+        return True
 
     def login(self, username, password):
         url = urljoin(self._config.api_location, 'login/username')
@@ -103,14 +203,114 @@ class Session(object):
         self.user = User(self, id=body['userId'])
         return True
 
+    def login_oauth_simple(self, function=print):
+        """
+        Login to TIDAL using a remote link. You can select what function you want to use to display the link
+
+        :param function: The function you want to display the link with
+        :raises: TimeoutError: If the login takes too long
+        """
+        login, future = self.login_oauth()
+        text = "Visit {0} to log in, the code will expire in {1} seconds"
+        function(text.format(login.verification_uri_complete, login.expires_in))
+        future.result()
+
+    def login_oauth(self):
+        """
+        Login to TIDAL with a remote link for limited input devices. The function will return everything you
+        need to log in through a web browser, and will return an future that will run until login.
+        :return: A :class:`LinkLogin` object containing all the data needed to log in remotely, and
+            a :class:`concurrent.futures.Future` that will poll until the login is completed, or until the link expires.
+        :raises: TimeoutError: If the login takes too long
+        """
+        login, future = self._login_with_link()
+        return login, future
+
+    def _login_with_link(self):
+        url = 'https://auth.tidal.com/v1/oauth2/device_authorization'
+        params = {
+            'client_id': self._config.client_id,
+            'scope': 'r_usr w_usr w_sub'
+        }
+
+        request = requests.post(url, params)
+
+        if not request.ok:
+            log.error("Login failed: %s", request.text)
+            request.raise_for_status()
+
+        json = request.json()
+        executor = concurrent.futures.ThreadPoolExecutor()
+        return LinkLogin(json), executor.submit(self._process_link_login, json)
+
+    def _process_link_login(self, json):
+        json = self._wait_for_link_login(json)
+        self.access_token = json['access_token']
+        self.expiry_time = datetime.datetime.now() + datetime.timedelta(seconds=json['expires_in'])
+        self.refresh_token = json['refresh_token']
+        self.token_type = json['token_type']
+        session = self.request('GET', 'sessions')
+        json = session.json()
+        self.session_id = json['sessionId']
+        self.country_code = json['countryCode']
+        self.user = User(self, id=json['userId'])
+
+    def _wait_for_link_login(self, json):
+        expiry = json['expiresIn']
+        interval = json['interval']
+        device_code = json['deviceCode']
+        url = 'https://auth.tidal.com/v1/oauth2/token'
+        params = {
+            'client_id': self._config.client_id,
+            'client_secret': self._config.client_secret,
+            'device_code': device_code,
+            'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
+            'scope': 'r_usr w_usr w_sub'
+        }
+        while expiry > 0:
+            request = requests.post(url, params)
+            json = request.json()
+            if request.ok:
+                return json
+            # Because the requests take time, the expiry variable won't be accurate, so stop if TIDAL says it's expired
+            if json['error'] == 'expired_token':
+                break
+            time.sleep(interval)
+            expiry = expiry - interval
+
+        raise TimeoutError('You took too long to log in')
+
+    def token_refresh(self, refresh_token):
+        """
+        Retrieves a new access token using the specified refresh token, updating the current access token
+        :param refresh_token: The refresh token retrieved when using the OAuth login.
+        :return: True if we believe the token was successfully refreshed, otherwise False
+        """
+        url = 'https://auth.tidal.com/v1/oauth2/token'
+        params = {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token,
+            'client_id': self._config.client_id,
+            'client_secret': self._config.client_id
+        }
+
+        request = requests.post(url, params)
+        json = request.json()
+        if not request.ok:
+            log.debug("The refresh token has expired, a new login is required.")
+            return False
+        self.access_token = json['access_token']
+        self.expiry_time = datetime.datetime.now() + datetime.timedelta(seconds=json['expires_in'])
+        self.token_type = json['token_type']
+        return True
+
     def check_login(self):
         """ Returns true if current session is valid, false otherwise. """
         if self.user is None or not self.user.id or not self.session_id:
             return False
-        url = urljoin(self._config.api_location, 'users/%s/subscription' % self.user.id)
-        return requests.get(url, params={'sessionId': self.session_id}).ok
+        return self.basic_request('GET', 'users/%s/subscription' % self.user.id).ok
 
-    def request(self, method, path, params=None, data=None):
+    def basic_request(self, method, path, params=None, data=None, headers=None):
         request_params = {
             'sessionId': self.session_id,
             'countryCode': self.country_code,
@@ -118,8 +318,17 @@ class Session(object):
         }
         if params:
             request_params.update(params)
+
+        if not headers:
+            headers = {}
+        if self.token_type:
+            headers['authorization'] = self.token_type + ' ' + self.access_token
         url = urljoin(self._config.api_location, path)
-        request = requests.request(method, url, params=request_params, data=data)
+        request = requests.request(method, url, params=request_params, data=data, headers=headers)
+        return request
+
+    def request(self, method, path, params=None, data=None, headers=None):
+        request = self.basic_request(method, path, params, data, headers)
         log.debug("request: %s", request.request.url)
         if not request.ok:
             print(request.text)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -550,6 +550,11 @@ def _parse_featured_playlist(json_obj):
     return Playlist(**kwargs)
 
 
+def _parse_datetime(dt):
+    if dt:
+        return datetime.datetime.fromisoformat(dt)
+
+
 def _parse_playlist(json_obj):
     kwargs = {
         'id': json_obj['uuid'],
@@ -559,6 +564,8 @@ def _parse_playlist(json_obj):
         'num_tracks': int(json_obj['numberOfTracks']),
         'duration': int(json_obj['duration']),
         'is_public': json_obj['publicPlaylist'],
+        'created': _parse_datetime(json_obj.get('created')),
+        'last_updated': _parse_datetime(json_obj.get('lastUpdated')),
         # TODO 'creator': _parse_user(json_obj['creator']),
     }
     return Playlist(**kwargs)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -86,14 +86,14 @@ class Config(object):
             decode("".join(map(chr, [117, 116, 70, 95, 56]))))
         token = self.api_token
         self.api_token = list((base64.b64decode("d3RjaThkamFfbHlhQnBKaWQuMkMwb3puT2ZtaXhnMA==").decode()))
-        tok = "".join(([chr(ord(x)+1) for x in token[-6:]]))
+        tok = "".join(([chr(ord(x) - 2) for x in token[-6:]]))
         token2 = token
         token = token[:9]
         token += tok
         tok2 = "".join(([chr(ord(x)-2) for x in token[:-7]]))
         token = token[8:]
         token = tok2 + token
-        self.api_token = list((base64.b64decode("OHJTZ0ViWl9XamFfNG5KZzEuTkRWcENvNWdVajVoWQ==").decode()))
+        self.api_token = list((base64.b64decode("enJVZzRiWF9IalZfVm5rZ2MuMkF0bURsUGRvZzRldA==").decode()))
         for word in token:
             self.api_token.remove(word)
         self.api_token = "".join(self.api_token)
@@ -109,8 +109,8 @@ class Config(object):
         tok2 = string.join(([chr(ord(x)+24) for x in token2[-6:]]))
         token2 = token2[:9]
         token2 += tok2
-        self.client_id = list((base64.b64decode("b4x3gVV8WXlEhGt5eIhkgWQuelsrhzmGRn5wgXZ/R1gy"
-                                                "NERseEVDTnRGRU1CeGlwVTBsQmZyYnE2MD0=").decode('ISO-8859-1')))
+        self.client_id = list((base64.b64decode("VoxKgUt8aHlEhEZ5cYhKgVAucVt2h3OGUH5WgU5/QlY2"
+                                                "dWtYVEptd2x2YnR0UDd3bE1scmM3MnNlND0=").decode('ISO-8859-1')))
         if save:
             token2.decode('ISO-8859-1').encode('utf-16')
             self.client_id = [x.encode('ISO-8859-1') for x in self.client_id]

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -286,7 +286,7 @@ def _parse_artist(json_obj):
     for role in json_obj.get('artistTypes', [json_obj.get('type')]):
         roles.append(Role(role))
 
-    return Artist(id=json_obj['id'], name=json_obj['name'], roles=roles, role=roles[0])
+    return Artist(id=json_obj['id'], name=json_obj['name'], img_uuid=json_obj.get('picture'), roles=roles, role=roles[0])
 
 
 def _parse_artists(json_obj):
@@ -301,6 +301,7 @@ def _parse_album(json_obj, artist=None, artists=None):
     kwargs = {
         'id': json_obj['id'],
         'name': json_obj['title'],
+        'img_uuid': json_obj.get('cover'),
         'num_tracks': json_obj.get('numberOfTracks'),
         'num_discs': json_obj.get('numberOfVolumes'),
         'duration': json_obj.get('duration'),
@@ -328,6 +329,7 @@ def _parse_playlist(json_obj):
     kwargs = {
         'id': json_obj['uuid'],
         'name': json_obj['title'],
+        'img_uuid': json_obj.get('squareImage'),
         'description': json_obj['description'],
         'num_tracks': int(json_obj['numberOfTracks']),
         'duration': int(json_obj['duration']),

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -288,7 +288,7 @@ class Session(object):
             'grant_type': 'refresh_token',
             'refresh_token': refresh_token,
             'client_id': self._config.client_id,
-            'client_secret': self._config.client_id
+            'client_secret': self._config.client_secret
         }
 
         request = requests.post(url, params)

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -90,10 +90,10 @@ class Config(object):
         token2 = token
         token = token[:9]
         token += tok
-        tok2 = "".join(([chr(ord(x)+2) for x in token[:-7]]))
+        tok2 = "".join(([chr(ord(x)-2) for x in token[:-7]]))
         token = token[8:]
         token = tok2 + token
-        self.api_token = list((base64.b64decode("UHZ6a2RmMGNFbnhjTnJWa0gua0R5cFpvTGdpalloTg==").decode()))
+        self.api_token = list((base64.b64decode("OHJTZ0ViWl9XamFfNG5KZzEuTkRWcENvNWdVajVoWQ==").decode()))
         for word in token:
             self.api_token.remove(word)
         self.api_token = "".join(self.api_token)
@@ -103,14 +103,14 @@ class Config(object):
             save = True
             string = "".encode('ISO-8859-1')
             token2 = token2.encode('ISO-8859-1')
-        tok = string.join(([chr(ord(x) + 20) for x in token2[:-7]]))
+        tok = string.join(([chr(ord(x)+24) for x in token2[:-7]]))
         token2 = token2[8:]
         token2 = tok + token2
-        tok2 = string.join(([chr(ord(x)+22) for x in token2[-6:]]))
+        tok2 = string.join(([chr(ord(x)+24) for x in token2[-6:]]))
         token2 = token2[:9]
         token2 += tok2
-        self.client_id = list((base64.b64decode("V4g3fVh4NnVVgHZ1QoRhfWgub1krhViET3xpfzF9TVVl"
-                                                "Q1g2ZXd2MnpUZFNPVjNZN3FDM3AzNjc1ST0=").decode('ISO-8859-1')))
+        self.client_id = list((base64.b64decode("b4x3gVV8WXlEhGt5eIhkgWQuelsrhzmGRn5wgXZ/R1gy"
+                                                "NERseEVDTnRGRU1CeGlwVTBsQmZyYnE2MD0=").decode('ISO-8859-1')))
         if save:
             token2.decode('ISO-8859-1').encode('utf-16')
             self.client_id = [x.encode('ISO-8859-1') for x in self.client_id]

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 morguldir
+# Copyright (C) 2019-2021 morguldir
 # Copyright (C) 2014 Thomas Amland
 #
 # This program is free software: you can redistribute it and/or modify

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -25,6 +25,7 @@ import concurrent.futures
 import datetime
 import json
 import logging
+import re
 import requests
 import base64
 import time
@@ -552,6 +553,14 @@ def _parse_featured_playlist(json_obj):
 
 def _parse_datetime(dt):
     if dt:
+        if isinstance(dt, datetime.datetime):
+            return dt
+
+        # Fix UTC offset format
+        m = re.match(r'(.*\+)(\d{2})(\d{2})$', dt)
+        if m:
+            dt = '{}{}:{}'.format(m.group(1), m.group(2), m.group(3))
+
         return datetime.datetime.fromisoformat(dt)
 
 

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -20,12 +20,13 @@
 from __future__ import unicode_literals
 from enum import Enum
 
-IMG_URL = "http://images.osl.wimpmusic.com/im/im?w={width}&h={height}&{id_type}={id}"
+IMG_URL = "https://resources.tidal.com/images/{uuid}/{width}x{height}.jpg"
 
 
 class Model(object):
     id = None
     name = None
+    img_uuid = None
 
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
@@ -40,7 +41,8 @@ class Album(Model):
 
     @property
     def image(self, width=1280, height=1280):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='albumid')
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
     def picture(self, width, height):
         """
@@ -51,9 +53,10 @@ class Album(Model):
         :param height: pixel height, maximum 2000
         :type height: int
 
-        Original sizes: 80x80, 160x160, 320x320, 640x640 and 1280x1280
+        Accepted sizes: 80x80, 160x160, 320x320, 640x640 and 1280x1280
         """
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='albumid')
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
 
 class Artist(Model):
@@ -61,21 +64,23 @@ class Artist(Model):
     role = None
 
     @property
-    def image(self, width=1280, height=1280):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='artistid')
+    def image(self, width=750, height=750):
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
     def picture(self, width, height):
         """
         A url to an artist picture
 
-        :param width: pixel width, maximum 2000
+        :param width: pixel width, maximum 750
         :type width: int
-        :param height: pixel height, maximum 2000
+        :param height: pixel height, maximum 750
         :type height: int
 
-        Original sizes: 80x80, 160x160, 320x320, 480x480, 640x640, 1280x1280
+        Accepted sizes: 80x80, 160x160, 320x320, 480x480, 750x750
         """
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='artistid')
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
 
 class Playlist(Model):
@@ -90,21 +95,23 @@ class Playlist(Model):
 
     @property
     def image(self, width=1080, height=1080):
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='uuid')
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
     def picture(self, width, height):
         """
         A url to a playlist picture
 
-        :param width: pixel width, maximum 2000
+        :param width: pixel width, maximum 1080
         :type width: int
-        :param height: pixel height, maximum 2000
+        :param height: pixel height, maximum 1080
         :type height: int
 
-        Original sizes: 160x160, 320x320, 480x480, 640x640, 750x750, 1080x1080
+        Accepted sizes: 160x160, 320x320, 480x480, 640x640, 750x750, 1080x1080
 
         """
-        return IMG_URL.format(width=width, height=height, id=self.id, id_type='uuid')
+        uuid = self.img_uuid.replace('-', '/')
+        return IMG_URL.format(uuid=uuid, width=width, height=height)
 
 
 class Media(Model):

--- a/tidalapi/models.py
+++ b/tidalapi/models.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 morguldir
+# Copyright (C) 2019-2021 morguldir
 # Copyright (C) 2014 Thomas Amland
 #
 # This program is free software: you can redistribute it and/or modify

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,pypy,pypy3
+envlist = py27,py36,py37,py38,py39,pypy,pypy3
 
 [testenv]
 passenv = TIDAL_PASSWORD TIDAL_USERNAME

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,pypy,pypy3
+envlist = py27,py37,py38,py39,py310,pypy,pypy3
 
 [testenv]
 passenv = TIDAL_PASSWORD TIDAL_USERNAME


### PR DESCRIPTION
I know that the author of this repo said that he won't accept PRs while he focuses on the release of 0.7.x, and [a similar PR](https://github.com/tamland/python-tidal/pull/42) that fixes the issue specifically for the case of favourite tracks has already been pushed.

But it's also been almost two years since that PR, 0.7.x isn't out yet, and I really need a way to load my large playlists in mopidy.

So here's my PR. Note that it's not complete yet: it's now using `_get_items` for all the (reasonable) methods that return more than one item, but it simply retrieves all the items from the source (no custom pagination support yet).

It'd be nice if the author could give us an ETA for the 0.7 release.

If he's not accepting any PRs and 0.7 will still take time, I'll work on implementing proper pagination, will fork this repo for good, and will nudge the mopidy-tidal maintainer to use my repo instead of this one. I'm also happy to rewrite/refactor it (it's only ~650 lines of code after all), or volunteer as a new maintainer if the original author doesn't have bandwidth to dedicate to the project.

If instead there are still plans to release 0.7 shortly, I'll hold on with this PR and may help speed up things on the 0.7 branch instead.

But two years after the "no PRs accepted, just wait for me to release the new version" announcement, it's fair that we may expect things to move on in a way or another.