### PR TITLE
Use extend instead of for..append to update the items list

### DIFF
--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -149,6 +149,5 @@ class Requests(object):
             items = self.map_request(url, params=params, parse=parse)
             remaining = len(items)
             params['offset'] += 100
-            for item in items:
-                item_list.append(item)
+            item_list.extend(items or [])
         return item_list


### PR DESCRIPTION
The performance of `extend` is much better in case of large lists.
Example:

```python
import timeit

def list_append():
    l = []
    for n in range(10000):
        l.append(n)

def list_extend():
    l = []
    l.extend(range(10000))

print('With append: {}'.format(
    timeit.timeit(list_append, number=10000)
))

print('With extend: {}'.format(
    timeit.timeit(list_extend, number=10000)
))
```

Output:

```
With append: 5.770571048022248
With extend: 1.5647333190136123
```