### PR TITLE
Added function for multiple deletions at once

### DIFF
--- a/tidalapi/playlist.py
+++ b/tidalapi/playlist.py
@@ -205,6 +205,12 @@ class UserPlaylist(Playlist):
         headers = {'If-None-Match': self._etag}
         self.requests.request('DELETE', (self._base_url + '/items/%i') % (self.id, index), headers=headers)
 
+    def remove_by_indices(self, indices):
+        headers = {'If-None-Match': self._etag}
+        track_index_string = ",".join([str(x) for x in indices])
+        self.requests.request('DELETE', (self._base_url + '/tracks/%s') % (self.id, track_index_string),
+                                 headers=headers)
+
     def _calculate_id(self, media_id):
         i = 0
         while i < self.num_tracks:


### PR DESCRIPTION
This may be an unuseful edit for the most users, but I need for my code to delete a bunch of tracks at once.  It would spam the api to much, if I would delete index by index. Instead I just can give it an array (e.g. [4, 10, 9, 25]) and it would delete all these songs