### PR TITLE
New attribute to media.Track() class: 'full_name'

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -171,3 +171,24 @@ def test_video_image(session):
 
     with pytest.raises(AssertionError):
         verify_image_resolution(session, video.image(1080, 720), 1270, 1270)
+
+
+def test_full_name_track_1(session):
+    track = session.track(149119714)
+    assert track.name == "Fibonacci Progressions (Keemiyo Remix)"
+    assert track.version == None
+    assert track.full_name == "Fibonacci Progressions (Keemiyo Remix)"
+
+def test_full_name_track_2(session):
+    track = session.track(78495659)
+    assert track.name == "Bullitt"
+    assert track.version == "Bonus Track"
+    assert track.full_name == "Bullitt (Bonus Track)"
+
+def test_full_name_track_3(session):
+    track = session.track(98849340)
+    assert track.name == "Magical place (feat. IOVA)"
+    assert track.version == "Dj Dark & MD Dj Remix"
+    assert track.full_name == "Magical place (feat. IOVA) (Dj Dark & MD Dj Remix)"
+
+

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -129,6 +129,7 @@ class Track(Media):
     isrc = None
     audio_quality = None
     version = None
+    full_name = None
     copyright = None
 
     def parse_track(self, json_obj):
@@ -141,6 +142,11 @@ class Track(Media):
             self.copyright = json_obj['copyright']
         self.audio_quality = tidalapi.Quality(json_obj['audioQuality'])
         self.version = json_obj['version']
+
+        if self.version is not None:
+            self.full_name = (f"{json_obj['title']} ({json_obj['version']})")
+        else:
+            self.full_name = json_obj['title']
 
         return copy.copy(self)
 


### PR DESCRIPTION
The objects of the tidalapi.media.Tracks() class have a new attribute: full_name.
It contains the title / name of the song + the 'version'. The version is used to add information on what version of the track this is; when it's a remixed version of the song it contains the name of the remix artist, if it's the radio version or the extended version etc. this is usually the place where that information is found.

However, the use of that attribute is inconsistent: Some tracks use it, others put that information directly in to the title / name of the track. The 'full_name' attribute aims to provide that consistency by adding 'name' and 'version' together when the 'version' attribute is used by that song.