### PR TITLE
fix Track.stream() method

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -198,7 +198,7 @@ class Track(Media):
             'audioquality' : self.session.config.quality,
             'assetpresentation': 'FULL',
         }
-        return self.requests.map_request('GET', 'tracks/%s/playbackinfopostpaywall' % self.id, params, parse=Stream().parse)
+        return self.requests.map_request('tracks/%s/playbackinfopostpaywall' % self.id, params, parse=Stream().parse)
 
       
 class Stream(object):


### PR DESCRIPTION
The current stream method tries to call map_request() with an argument that was probably removed at some point which raises an exception.