### PR TITLE
#146: Fixed key error for gender when parsing user json

### DIFF
--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -111,7 +111,7 @@ class LoggedInUser(FetchedUser):
         self.created = dateutil.parser.isoparse(json_obj["created"])
         self.newsletter = json_obj["newsletter"]
         self.accepted_eula = json_obj["acceptedEULA"]
-        self.gender = json_obj["gender"]
+        self.gender = json_obj.get("gender", "not specified")
         self.date_of_birth = json_obj["dateOfBirth"]
         self.facebook_uid = json_obj["facebookUid"]
         self.apple_uid = json_obj["appleUid"]


### PR DESCRIPTION
Added a patch for the following issue: [#146 ](https://github.com/tamland/python-tidal/issues/146)

It seems that the JSON object returned by the Tidal API not longer contains the gender, maybe because it's not set in the user profile. It could make sense to use the `get` method for other keys, to mitigate this problem for the case, that data is missing in the JSON return object. For example newsletter, dateOfBirth... 