### PR TITLE
Downgrade minimum required version of requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-requests = "^2.31.0"
+requests = "^2.28.0"
 python-dateutil = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Downgrades minimum `requests` version to 2.28.0
- Adds `devdeps` make target


Last month, in https://github.com/tamland/python-tidal/commit/dc44738c9a2425ac6a2387cd5c02cad3bd5c68b2, @arusahni explicitly set the `requests` version to `^2.31.0`, the latest stable release. Obviously latest is ideal, especially when it's a [security release](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q). However on Arch Linux right now, the [python-tidalapi AUR package](https://aur.archlinux.org/packages/python-tidalapi) depends on [`python-requests` installed from the Arch `extra` repository](https://archlinux.org/packages/extra/any/python-requests/), which is currently at 2.28.2 (and has been flagged out of date for 3 months, unfortunately). Because of that, I currently can't use [mopidy-tidal](https://github.com/tehkillerbee/mopidy-tidal) installed from AUR either.

Since Python dependency management is a known pain in environments where a project is not sandboxed in a container or virtualenv, being slightly more permissive about dependency versions is ideal for ensuring compatibility is a bit more forgiving.
