### PR TITLE
Add typings for Artists and Users

### DIFF
--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -84,7 +84,7 @@ class Requests(object):
 
     def request(
         self,
-        method: Literal["GET", "POST", "PUT"],
+        method: Literal["GET", "POST", "PUT", "DELETE"],
         path: str,
         params: Optional[Params] = None,
         data: Optional[JsonObj] = None,

--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -19,12 +19,14 @@
 
 import json
 import logging
-from typing import Any, List
+from typing import Any, Callable, List, Literal, Mapping, Optional, Union
 from urllib.parse import urljoin
 
-import requests
+from tidalapi.types import JsonObj
 
 log = logging.getLogger(__name__)
+
+Params = Mapping[str, Union[str, int, None]]
 
 
 class Requests(object):
@@ -80,7 +82,14 @@ class Requests(object):
 
         return request
 
-    def request(self, method, path, params=None, data=None, headers=None):
+    def request(
+        self,
+        method: Literal["GET", "POST", "PUT"],
+        path: str,
+        params: Optional[Params] = None,
+        data: Optional[JsonObj] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ):
         """Method for tidal requests.
 
         Not meant for use outside of this library.
@@ -100,7 +109,12 @@ class Requests(object):
             log.debug("response: %s", json.dumps(request.json(), indent=4))
         return request
 
-    def map_request(self, url, params=None, parse=None):
+    def map_request(
+        self,
+        url: str,
+        params: Optional[Params] = None,
+        parse: Optional[Callable] = None,
+    ):
         """Returns the data about object(s) at the specified url, with the method
         specified in the parse argument.
 

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -189,7 +189,7 @@ TypeConversionKeys = Literal["identifier", "type", "parse"]
 class TypeRelation:
     identifier: str
     type: Optional[Any]
-    parse: function
+    parse: Callable
 
 
 class Session(object):
@@ -234,7 +234,7 @@ class Session(object):
         self.parse_page = self.page.parse
 
         self.type_conversions: List[TypeRelation] = [
-            TypeRelation(identifier=identifier, type=type, parse=parse)
+            TypeRelation(identifier=identifier, type=type, parse=cast(Callable, parse))
             for identifier, type, parse in zip(
                 (
                     "artists",

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -280,7 +280,9 @@ class Session(object):
 
         return result
 
-    def load_session(self, session_id, country_code=None, user_id=None):
+    def load_session(
+        self, session_id, country_code=None, user_id: Optional[int] = None
+    ):
         """Establishes TIDAL login details using a previous session id. May return true
         if the session-id is invalid/expired, you should verify the login afterwards.
 


### PR DESCRIPTION
Add typings for Artists and Users. Some notes:

1. Sorry for the bug I introduced with my last PR around circular imports and annotations. I took extra care this time around to verify that I have properly wrapped imported types in strings.
2. As with the previous PRs, the casts for requests are a necessary evil until we tackle that portion of the API surface.
3. I swapped the type of `TypeRelation.parse` back to `Callable` as it was interacting in funky ways with the types introduced here. I suppressed the error the `function` annotation was introduced to solve by adding a `cast`

Touches #137  