### PR TITLE
Feature/limit track radio

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def get_credential_store() -> tuple[List[Credentials], Optional[dict]]:
 
 def login(request):
     stores, credentials = get_credential_store()
-    config = tidalapi.Config(quality=tidalapi.Quality.master)
+    config = tidalapi.Config(quality=tidalapi.Quality.hi_res)
     tidal_session = tidalapi.Session(config)
     if credentials and tidal_session.load_oauth_session(**credentials):
         return tidal_session

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -50,7 +50,7 @@ def test_track(session):
     )
     assert track.isrc == "NOG841907010"
     assert track.explicit is False
-    assert track.audio_quality == tidalapi.Quality.master
+    assert track.audio_quality == tidalapi.Quality.hi_res
     assert track.album.name == "Alone, Pt. II"
 
     assert track.artist.name == "Alan Walker"
@@ -59,7 +59,7 @@ def test_track(session):
 
 
 def test_track_url(session):
-    session.config = tidalapi.Config(quality=tidalapi.Quality.master)
+    session.config = tidalapi.Config(quality=tidalapi.Quality.hi_res)
     track = session.track(142278122)
     assert "audio.tidal.com" in track.get_url()
 
@@ -212,3 +212,21 @@ def test_track_media_metadata_tags(session):
     track = session.track(182912246)
     assert track.name == "All You Ever Wanted"
     assert track.media_metadata_tags == ["LOSSLESS", "HIRES_LOSSLESS", "MQA"]
+
+
+def test_get_track_radio_limit_default(session):
+    track = session.track(182912246)
+    similar_tracks = track.get_track_radio()
+    assert len(similar_tracks) == 100
+    
+    
+def test_get_track_radio_limit_25(session):
+    track = session.track(182912246)
+    similar_tracks = track.get_track_radio(limit=25)
+    assert len(similar_tracks) == 25
+    
+    
+def test_get_track_radio_limit_100(session):
+    track = session.track(182912246)
+    similar_tracks = track.get_track_radio(limit=100)
+    assert len(similar_tracks) == 100

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -218,14 +218,14 @@ def test_get_track_radio_limit_default(session):
     track = session.track(182912246)
     similar_tracks = track.get_track_radio()
     assert len(similar_tracks) == 100
-    
-    
+
+
 def test_get_track_radio_limit_25(session):
     track = session.track(182912246)
     similar_tracks = track.get_track_radio(limit=25)
     assert len(similar_tracks) == 25
-    
-    
+
+
 def test_get_track_radio_limit_100(session):
     track = session.track(182912246)
     similar_tracks = track.get_track_radio(limit=100)

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -216,13 +216,13 @@ class Track(Media):
         assert not isinstance(lyrics, list)
         return cast("Lyrics", lyrics)
 
-    def get_track_radio(self) -> List["Track"]:
+    def get_track_radio(self, limit=100) -> List["Track"]:
         """Queries TIDAL for the track radio, which is a mix of tracks that are similar
         to this track.
 
         :return: A list of :class:`Tracks <tidalapi.media.Track>`
         """
-        params = {"limit": 100}
+        params = {"limit": limit}
         tracks = self.requests.map_request(
             "tracks/%s/radio" % self.id, params=params, parse=self.session.parse_track
         )


### PR DESCRIPTION
Adds the option to provide a limit to the track radio length, the default is still 100 as before.
Also added tests and fixed the conftest that was unchanged after the recent quality changes