### PR TITLE
Add typing to the Playlist and Page classes

### DIFF
--- a/tidalapi/artist.py
+++ b/tidalapi/artist.py
@@ -196,6 +196,14 @@ class Artist:
             ),
         )
 
+    def items(self) -> list:
+        """The artist page does not supply any items. This only exists for symmetry with
+        other model types.
+
+        :return: An empty list.
+        """
+        return []
+
     def image(self, dimensions: int = 320) -> str:
         """A url to an artist picture.
 

--- a/tidalapi/mix.py
+++ b/tidalapi/mix.py
@@ -72,7 +72,7 @@ class Mix:
     _retrieved = False
     _items: Optional[List[Union["Video", "Track"]]] = None
 
-    def __init__(self, session: Session, mix_id: str):
+    def __init__(self, session: Session, mix_id: Optional[str]):
         self.session = session
         self.request = session.request
         if mix_id is not None:

--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -19,7 +19,17 @@
 
 import json
 import logging
-from typing import Any, Callable, List, Literal, Mapping, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Union,
+    cast,
+)
 from urllib.parse import urljoin
 
 from tidalapi.types import JsonObj
@@ -27,6 +37,9 @@ from tidalapi.types import JsonObj
 log = logging.getLogger(__name__)
 
 Params = Mapping[str, Union[str, int, None]]
+
+if TYPE_CHECKING:
+    from tidalapi.session import Session
 
 
 class Requests(object):
@@ -131,10 +144,17 @@ class Requests(object):
         return self.map_json(json_obj, parse=parse)
 
     @classmethod
-    def map_json(cls, json_obj, parse=None, session=None):
+    def map_json(
+        cls,
+        json_obj: JsonObj,
+        parse: Optional[Callable] = None,
+        session: Optional["Session"] = None,
+    ) -> List[Any]:
         items = json_obj.get("items")
 
         if items is None:
+            if parse is None:
+                raise ValueError("A parser must be supplied")
             return parse(json_obj)
 
         if len(items) > 0 and "item" in items[0]:
@@ -143,15 +163,22 @@ class Requests(object):
                 for item in items:
                     item["item"]["dateAdded"] = item["created"]
 
-            lists = []
+            lists: List[Any] = []
             for item in items:
                 if session is not None:
-                    parse = session.convert_type(
-                        item["type"].lower() + "s", output="parse"
+                    parse = cast(
+                        Callable,
+                        session.convert_type(
+                            cast(str, item["type"]).lower() + "s", output="parse"
+                        ),
                     )
+                if parse is None:
+                    raise ValueError("A parser must be supplied")
                 lists.append(parse(item["item"]))
 
             return lists
+        if parse is None:
+            raise ValueError("A parser must be supplied")
         return list(map(parse, items))
 
     def get_items(self, url, parse):


### PR DESCRIPTION
This was the hairiest of the type conversions so far. It was complicated by the fact that the `Artist` class does not have an items collection. As a result, the `Page` iterator interface would end up raising an `AttributeError` if iteration was attempted. Rather than add a no-op `items` method to the the `Artist` type, I opted to shim it at the `Page` level to keep the API clean.

Please nitpick this! While I use the API, I've never used this module.

Advances #137 