### PR TITLE
209 fix tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,8 @@ def get_credential_store() -> tuple[List[Credentials], Optional[dict]]:
 
 def login(request):
     stores, credentials = get_credential_store()
-    config = tidalapi.Config(quality=tidalapi.Quality.hi_res)
+    config = tidalapi.Config()
+
     tidal_session = tidalapi.Session(config)
     if credentials and tidal_session.load_oauth_session(**credentials):
         return tidal_session

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -68,12 +68,13 @@ def test_get_albums_ep_singles(session):
 
 
 def test_get_albums_other(session):
-    artist = session.artist(16147)
+    artist = session.artist(17123)
     albums = [
-        session.album(108748620),
-        session.album(97216346),
+        session.album(327452387),
+        session.album(322406553),
     ]
-
+    other_albums = artist.get_albums_other
+    # artist_item_ids = [item.id for item in other_albums()]
     find_ids(albums, artist.get_albums_other)
 
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -99,7 +99,9 @@ def test_track_streaming(session):
     track = session.track(62392768)
     stream = track.stream()
     assert stream.audio_mode == "STEREO"
-    assert stream.audio_quality == tidalapi.Quality.low_320k.value # i.e. the default quality for the current session
+    assert (
+        stream.audio_quality == tidalapi.Quality.low_320k.value
+    )  # i.e. the default quality for the current session
 
 
 def test_video(session):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -59,7 +59,7 @@ def test_track(session):
 
 
 def test_track_url(session):
-    session.config = tidalapi.Config(quality=tidalapi.Quality.hi_res)
+    session.config = tidalapi.Config()
     track = session.track(142278122)
     assert "audio.tidal.com" in track.get_url()
 
@@ -99,7 +99,7 @@ def test_track_streaming(session):
     track = session.track(62392768)
     stream = track.stream()
     assert stream.audio_mode == "STEREO"
-    assert stream.audio_quality == "LOSSLESS"
+    assert stream.audio_quality == tidalapi.Quality.low_320k.value # i.e. the default quality for the current session
 
 
 def test_video(session):
@@ -110,7 +110,7 @@ def test_video(session):
     assert video.track_num == 0
     assert video.volume_num == 0
     assert video.release_date == datetime(2019, 12, 26, tzinfo=tz.tzutc())
-    assert video.tidal_release_date == datetime(2019, 12, 27, 8, tzinfo=tz.tzutc())
+    assert video.tidal_release_date == datetime(2019, 12, 27, 9, tzinfo=tz.tzutc())
     assert video.duration == 237
     assert video.video_quality == "MP4_1080P"
     assert video.available is True
@@ -161,7 +161,7 @@ def test_live_video(session):
     assert live.track_num == 1
     assert live.volume_num == 1
     assert live.release_date == datetime(2021, 4, 1, tzinfo=tz.tzutc())
-    assert live.tidal_release_date == datetime(2021, 4, 1, 17, tzinfo=tz.tzutc())
+    assert live.tidal_release_date == datetime(2021, 4, 1, 18, tzinfo=tz.tzutc())
     assert live.duration == 204
     assert live.video_quality == "MP4_1080P"
     assert live.available is True

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -110,7 +110,7 @@ def test_genres(session):
 def test_moods(session):
     moods = session.moods()
     first = next(iter(moods))
-    assert first.title == "Music School"
+    assert first.title == "Collabs"
     assert isinstance(next(iter(first.get())), tidalapi.Playlist)
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -98,7 +98,8 @@ def test_search(session):
     assert isinstance(search["tracks"][0], Track)
     assert isinstance(search["videos"][0], Video)
     assert isinstance(search["playlists"][0], Playlist)
-    assert "Walker" in search["top_hit"].artist.name
+    top_hit = search["top_hit"]
+    assert "Walker" in top_hit.name
 
 
 @pytest.mark.xfail(reason="Tidal now returns a video.")
@@ -130,7 +131,7 @@ def test_invalid_search(session):
 
 def test_config(session):
     assert session.config.item_limit == 1000
-    assert session.config.quality == tidalapi.Quality.low_320k.value
+    assert session.config.quality == tidalapi.Quality.low_320k.value # i.e. the default quality for the current session
     assert session.config.video_quality == tidalapi.VideoQuality.high.value
     assert session.config.alac is True
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -131,7 +131,9 @@ def test_invalid_search(session):
 
 def test_config(session):
     assert session.config.item_limit == 1000
-    assert session.config.quality == tidalapi.Quality.low_320k.value # i.e. the default quality for the current session
+    assert (
+        session.config.quality == tidalapi.Quality.low_320k.value
+    )  # i.e. the default quality for the current session
     assert session.config.video_quality == tidalapi.VideoQuality.high.value
     assert session.config.alac is True
 


### PR DESCRIPTION
This PR fixes various tests that broke during development or tidal API changes. Currently 

== 96 passed, 4 skipped, 1 xfailed, 1 xpassed, 2 warnings in 50.82s ======