### PR TITLE
Fix Page Recursion into Categories

### DIFF
--- a/tidalapi/page.py
+++ b/tidalapi/page.py
@@ -181,9 +181,9 @@ class PageCategory:
         elif category_type == "ARTIST_HEADER":
             result = self.session.parse_artist(json_obj["artist"])
             result.bio = json_obj["bio"]
-            return result
+            return ItemHeader(result)
         elif category_type == "ALBUM_HEADER":
-            return self.session.parse_album(json_obj["album"])
+            return ItemHeader(self.session.parse_album(json_obj["album"]))
         elif category_type == "HIGHLIGHT_MODULE":
             category = ItemList(self.session)
         elif category_type == "MIXED_TYPES_LIST":
@@ -362,6 +362,8 @@ class PageItem:
             return self.session.track(self.artifact_id)
         elif self.type == "ARTIST":
             return self.session.artist(self.artifact_id)
+        elif self.type == "ALBUM":
+            return self.session.album(self.artifact_id)
         raise NotImplementedError(f"PageItem type {self.type} not implemented")
 
 
@@ -397,3 +399,12 @@ class LinkList(PageCategory):
         self.description = json_obj["description"]
 
         return copy.copy(self)
+
+
+class ItemHeader(object):
+    """Single item in a "category" of the page."""
+
+    items: Optional[List[Any]] = None
+
+    def __init__(self, item: Any):
+        self.items = [item]


### PR DESCRIPTION
[Page iteration for child items]() expects PageCategory to have items but ALBUM_HEADER and ARTIST_HEADER is itself an item not an Object with items.
Wrapping those items in a pretend PageCategory so iteration will not throw an error.
Album has items itself but is a method and the error is even more confusing saying that items function can not be iterated.

Tests: local server test