### PR TITLE
✨ Removed return types from method names, but added deprecation warni…

### DIFF
--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -61,7 +61,7 @@ def test_get_albums(session):
     find_ids(albums, artist.get_albums)
 
 
-def test_get_albums_ep_singles(session):
+def test_get_ep_singles(session):
     artist = session.artist(16147)
     albums = [
         session.album(20903364),
@@ -71,18 +71,18 @@ def test_get_albums_ep_singles(session):
         session.album(19384377),
     ]
 
-    find_ids(albums, artist.get_albums_ep_singles)
+    find_ids(albums, artist.get_ep_singles)
 
 
-def test_get_albums_other(session):
+def test_get_other(session):
     artist = session.artist(17123)
     albums = [
         session.album(327452387),
         session.album(322406553),
     ]
-    other_albums = artist.get_albums_other
+    other_albums = artist.get_other
     # artist_item_ids = [item.id for item in other_albums()]
-    find_ids(albums, artist.get_albums_other)
+    find_ids(albums, artist.get_other)
 
 
 def test_get_top_tracks(session):

--- a/tidalapi/artist.py
+++ b/tidalapi/artist.py
@@ -126,6 +126,13 @@ class Artist:
         return self._get_albums(params)
 
     def get_albums_ep_singles(
+            self, limit: Optional[int] = None, offset: int = 0
+    ) -> List["Album"]:
+        print("This method is deprecated an will be removed in a future release. Use instead `get_ep_singles`")
+
+        return self.get_ep_singles(limit=limit, offset=offset)
+
+    def get_ep_singles(
         self, limit: Optional[int] = None, offset: int = 0
     ) -> List["Album"]:
         """Queries TIDAL for the artists extended plays and singles.
@@ -136,6 +143,13 @@ class Artist:
         return self._get_albums(params)
 
     def get_albums_other(
+            self, limit: Optional[int] = None, offset: int = 0
+    ) -> List["Album"]:
+        print("This method is deprecated an will be removed in a future release. Use instead `get_other`")
+
+        return self.get_other(limit=limit, offset=offset)
+
+    def get_other(
         self, limit: Optional[int] = None, offset: int = 0
     ) -> List["Album"]:
         """Queries TIDAL for albums the artist has appeared on as a featured artist.


### PR DESCRIPTION
…ngs instead. Fixes tamland/python-tidal#246

As discusses here: https://github.com/tamland/python-tidal/issues/246