### PR TITLE
Add support for get track by ISRC and get album by BarcodeID

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 History
 =======
+v0.7.7
+------
+* Add support to get tracks by ISRC - M4TH1EU_
+* Add support to get albums by Barcode ID (UPC)  - M4TH1EU_
 
 v0.7.6
 ------
@@ -178,6 +182,7 @@ v0.6.2
 .. _arnesongit: https://github.com/arnesongit
 .. _Jimmyscene: https://github.com/Jimmyscene
 .. _quodrum-glas: https://github.com/quodrum-glas
+.. _M4TH1EU: https://github.com/M4TH1EU
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tidalapi"
-version = "0.7.6"
+version = "0.7.7"
 description = "Unofficial API for TIDAL music streaming service."
 authors = ["Thomas Amland <thomas.amland@googlemail.com>"]
 maintainers = ["tehkillerbee <tehkillerbee@users.noreply.github.com>"]

--- a/tidalapi/__init__.py
+++ b/tidalapi/__init__.py
@@ -19,4 +19,4 @@ from .user import (  # noqa: F401
     User,
 )
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"

--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -67,6 +67,7 @@ class Requests(object):
         params: Optional[Params] = None,
         data: Optional[JsonObj] = None,
         headers: Optional[MutableMapping[str, str]] = None,
+        base_url: Optional[str] = None,
     ) -> requests.Response:
         request_params = {
             "sessionId": self.session.session_id,
@@ -90,7 +91,10 @@ class Requests(object):
             headers["authorization"] = (
                 self.session.token_type + " " + self.session.access_token
             )
-        url = urljoin(self.session.config.api_v1_location, path)
+        if base_url is None:
+            base_url = self.session.config.api_v1_location
+
+        url = urljoin(base_url, path)
         request = self.session.request_session.request(
             method, url, params=request_params, data=data, headers=headers
         )
@@ -123,6 +127,7 @@ class Requests(object):
         params: Optional[Params] = None,
         data: Optional[JsonObj] = None,
         headers: Optional[MutableMapping[str, str]] = None,
+        base_url: Optional[str] = None,
     ) -> requests.Response:
         """Method for tidal requests.
 
@@ -133,10 +138,11 @@ class Requests(object):
         :param params: The parameters you want to supply with the request.
         :param data: The data you want to supply with the request.
         :param headers: The headers you want to include with the request
+        :param base_url: The base url to use for the request
         :return: The json data at specified api endpoint.
         """
 
-        request = self.basic_request(method, path, params, data, headers)
+        request = self.basic_request(method, path, params, data, headers, base_url)
         log.debug("request: %s", request.request.url)
         try:
             request.raise_for_status()

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -857,6 +857,46 @@ class Session:
             log.warning("Track '%s' is unavailable", track_id)
             raise
 
+    def get_tracks_by_isrc(self, isrc: str) -> list[media.Track]:
+        """Function to search all tracks with a specific ISRC code.
+
+        :param isrc: The ISRC of the Track.
+        :return: Returns a list of :class:`.Track` objects that have access to the session instance used.
+        """
+        try:
+            res = self.request.request(
+                "GET",
+                "tracks",
+                params={
+                    "filter[isrc]": isrc,
+                },
+                base_url="https://openapi.tidal.com/v2/").json()
+
+            return [self.track(track['id']) for track in res['data']]
+        except requests.HTTPError:
+            log.warning("Wrong ISRC code '%s'", isrc)
+            raise
+
+    def get_albums_by_barcode(self, barcode: str) -> list[album.Album]:
+        """Function to search all albums with a specific UPC code.
+
+        :param barcode: The UPC of the Album.
+        :return: Returns a list of :class:`.Album` objects that have access to the session instance used.
+        """
+        try:
+            res = self.request.request(
+                "GET",
+                "albums",
+                params={
+                    "filter[barcodeId]": barcode,
+                },
+                base_url="https://openapi.tidal.com/v2/").json()
+
+            return [self.album(album['id']) for album in res['data']]
+        except HTTPError:
+            log.warning("Wrong barcode '%s'", barcode)
+            raise
+
     def video(self, video_id: Optional[str] = None) -> media.Video:
         """Function to create a Video object with access to the session instance in a
         smoother way. Calls :class:`tidalapi.Video(session=session, video_id=video_id)


### PR DESCRIPTION
I had to add support for a custom base url in request() and basic_request() to use the new api.

See here for API documentation : https://apiref.developer.tidal.com
Uses the filter[x] param.

Shouldn't have any impact on the other functionalities.

Would fix https://github.com/tamland/python-tidal/issues/96
