### PR TITLE
Feature/v0.7.7-prep

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 =======
 v0.7.7
 ------
+* Feat.: Provide "Share Link", "Listen link" as an attribute to album/artist/media. Add relevant tests (Fixes #266) - tehkillerbee_
 * Allow switching authentication method oauth/pkce for tests. Default: oauth - tehkillerbee_
 * Tests: Added track stream tests (BTS, MPD) - tehkillerbee_
 * Bugfix: Always use last element in segment timeline. (Fixes #273) - tehkillerbee_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ History
 =======
 v0.7.7
 ------
+* Allow switching authentication method oauth/pkce for tests. Default: oauth - tehkillerbee_
+* Tests: Added track stream tests (BTS, MPD) - tehkillerbee_
+* Bugfix: Always use last element in segment timeline. (Fixes #273) - tehkillerbee_
 * Add method to get detailed request error response if an error occurred during request. - tehkillerbee_
 * Tests: Add tests tests for ISRC, barcode methods and cleanup exception handling. - tehkillerbee_
 * Feat.: Add support to get tracks by ISRC. - tehkillerbee_, M4TH1EU_

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -49,6 +49,8 @@ def test_album(session):
     assert 0 < album.popularity < 100
     assert album.artist.name == "Lasgo"
     assert album.artists[0].name == "Lasgo"
+    assert album.listen_url == "https://listen.tidal.com/album/17927863"
+    assert album.share_url == "https://tidal.com/browse/album/17927863"
 
     with pytest.raises(AttributeError):
         session.album(17927863).video(1280)

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -30,6 +30,8 @@ def test_artist(session):
     artist = session.artist(16147)
     assert artist.id == 16147
     assert artist.name == "Lasgo"
+    assert artist.listen_url == "https://listen.tidal.com/artist/16147"
+    assert artist.share_url == "https://tidal.com/browse/artist/16147"
     assert all(
         role in artist.roles
         for role in [tidalapi.Role.artist, tidalapi.Role.contributor]

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -20,11 +20,10 @@
 from datetime import datetime
 
 import pytest
-import requests
 from dateutil import tz
 
 import tidalapi
-from tidalapi.exceptions import MetadataNotAvailable, ObjectNotFound
+from tidalapi.exceptions import MetadataNotAvailable
 from tidalapi.media import AudioExtensions, AudioMode, ManifestMimeType, MimeType
 
 from .cover import verify_image_resolution, verify_video_resolution
@@ -53,8 +52,13 @@ def test_track(session):
     )
     assert track.isrc == "NOG841907010"
     assert track.explicit is False
-    assert track.audio_quality == tidalapi.Quality.hi_res
+    assert track.audio_quality == tidalapi.Quality.high_lossless
     assert track.album.name == "Alone, Pt. II"
+    assert track.album.id == 125169472
+    assert (
+        track.listen_url == "https://listen.tidal.com/album/125169472/track/125169484"
+    )
+    assert track.share_url == "https://tidal.com/browse/track/125169484"
 
     assert track.artist.name == "Alan Walker"
     artist_names = [artist.name for artist in track.artists]
@@ -123,8 +127,12 @@ def test_video(session):
     assert video.album is None
 
     assert video.artist.name == "Alan Walker"
+    assert video.artist.id == 6159368
     artist_names = [artist.name for artist in video.artists]
     assert [artist in artist_names for artist in ["Alan Walker", "Ava Max"]]
+
+    assert video.listen_url == "https://listen.tidal.com/artist/6159368/video/125506698"
+    assert video.share_url == "https://tidal.com/browse/video/125506698"
 
 
 def test_video_no_release_date(session):

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -73,6 +73,11 @@ class Album:
     artist: Optional["Artist"] = None
     artists: Optional[List["Artist"]] = None
 
+    # Direct URL to https://listen.tidal.com/album/<album_id>
+    listen_url: str = ""
+    # Direct URL to https://tidal.com/browse/album/<album_id>
+    share_url: str = ""
+
     def __init__(self, session: "Session", album_id: Optional[str]):
         self.session = session
         self.request = session.request
@@ -148,6 +153,8 @@ class Album:
         self.user_date_added = (
             dateutil.parser.isoparse(user_date_added) if user_date_added else None
         )
+        self.listen_url = f"{self.session.config.listen_base_url}/album/{self.id}"
+        self.share_url = f"{self.session.config.share_base_url}/album/{self.id}"
 
         return copy.copy(self)
 

--- a/tidalapi/artist.py
+++ b/tidalapi/artist.py
@@ -48,6 +48,11 @@ class Artist:
     user_date_added: Optional[datetime] = None
     bio: Optional[str] = None
 
+    # Direct URL to https://listen.tidal.com/artist/<artist_id>
+    listen_url: str = ""
+    # Direct URL to https://tidal.com/browse/artist/<artist_id>
+    share_url: str = ""
+
     def __init__(self, session: "Session", artist_id: Optional[str]):
         """Initialize the :class:`Artist` object, given a TIDAL artist ID :param
         session: The current TIDAL :class:`Session` :param str artist_id: TIDAL artist
@@ -96,6 +101,9 @@ class Artist:
         self.user_date_added = (
             dateutil.parser.isoparse(user_date_added) if user_date_added else None
         )
+
+        self.listen_url = f"{self.session.config.listen_base_url}/artist/{self.id}"
+        self.share_url = f"{self.session.config.share_base_url}/artist/{self.id}"
 
         return copy.copy(self)
 

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -721,7 +721,7 @@ class DashInfo:
             .representations[0]
             .segment_templates[0]
             .segment_timelines[0]
-            .Ss[1]
+            .Ss[-1]  # Always use last element in segment timeline.
             .d
         )
 

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -141,6 +141,7 @@ class Codec(str, Enum):
 class MimeType(str, Enum):
     audio_mpeg = "audio/mpeg"
     audio_mp3 = "audio/mp3"
+    audio_mp4 = "audio/mp4"
     audio_m4a = "audio/m4a"
     audio_flac = "audio/flac"
     audio_xflac = "audio/x-flac"

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -200,6 +200,10 @@ class Media:
     artists: Optional[List["tidalapi.artist.Artist"]] = None
     album: Optional["tidalapi.album.Album"] = None
     type: Optional[str] = None
+    # Direct URL to media https://listen.tidal.com/track/<id> or https://listen.tidal.com/browse/album/<album_id>/track/<track_id>
+    listen_url: str = ""
+    # Direct URL to media https://tidal.com/browse/track/<id>
+    share_url: str = ""
 
     def __init__(
         self, session: "tidalapi.session.Session", media_id: Optional[str] = None
@@ -306,6 +310,12 @@ class Track(Media):
             self.full_name = f"{json_obj['title']} ({json_obj['version']})"
         else:
             self.full_name = json_obj["title"]
+        # Generate share URLs from track ID and album (if it exists)
+        if self.album:
+            self.listen_url = f"{self.session.config.listen_base_url}/album/{self.album.id}/track/{self.id}"
+        else:
+            self.listen_url = f"{self.session.config.listen_base_url}/track/{self.id}"
+        self.share_url = f"{self.session.config.share_base_url}/track/{self.id}"
 
         return copy.copy(self)
 
@@ -816,6 +826,13 @@ class Video(Media):
         self.cover = json_obj["imageId"]
         # Videos found in the /pages endpoints don't have quality
         self.video_quality = json_obj.get("quality")
+
+        # Generate share URLs from track ID and artist (if it exists)
+        if self.artist:
+            self.listen_url = f"{self.session.config.listen_base_url}/artist/{self.artist.id}/video/{self.id}"
+        else:
+            self.listen_url = f"{self.session.config.listen_base_url}/video/{self.id}"
+        self.share_url = f"{self.session.config.share_base_url}/video/{self.id}"
 
         return copy.copy(self)
 

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -119,6 +119,9 @@ class Config:
     code_challenge: str
     pkce_uri_redirect: str = "https://tidal.com/android/login/auth"
     client_id_pkce: str
+    # Base URLs for sharing, listen URLs
+    listen_base_url: str = "https://listen.tidal.com"
+    share_base_url: str = "https://tidal.com/browse"
 
     @no_type_check
     def __init__(


### PR DESCRIPTION
Preparation for v.0.7.7
*  Always use last element in segment timeline. (Fixes #273) 
* Added track stream tests (BTS, MPD)
* Allow switching authentication method oauth/pkce for tests
*  Provide "Share Link", "Listen link" as an attribute (Fixes #266) 
* Test share URLs, listen URLs for album, artist, media