### PR TITLE
Feature/v.0.7.7 prep2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 =======
 v0.7.7
 ------
+* Bugfix: Fix linting for audio_modes. Update tests (Fixes #261) - tehkillerbee_
 * Feat.: Provide "Share Link", "Listen link" as an attribute to album/artist/media. Add relevant tests (Fixes #266) - tehkillerbee_
 * Allow switching authentication method oauth/pkce for tests. Default: oauth - tehkillerbee_
 * Tests: Added track stream tests (BTS, MPD) - tehkillerbee_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 =======
 v0.7.7
 ------
+* Bugfix: Ensure manifest.codecs always uses a Codec type for both MPD and BTS. - tehkillerbee_
+* Added additional tests to verify stream formats (Relates to #252) - tehkillerbee_
+* BREAKING: Fix naming of getters to align with python naming convention and avoid confusion (Fixes #255) - tehkillerbee_
+* Bugfix: Use correct internal type int for relevant IDs (Fixes #260) - tehkillerbee_
 * Bugfix: Fix linting for audio_modes. Update tests (Fixes #261) - tehkillerbee_
 * Feat.: Provide "Share Link", "Listen link" as an attribute to album/artist/media. Add relevant tests (Fixes #266) - tehkillerbee_
 * Allow switching authentication method oauth/pkce for tests. Default: oauth - tehkillerbee_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,12 +4,15 @@ History
 =======
 v0.7.7
 ------
+* Tests: Fix all tests that previously failed. - tehkillerbee_
+* Use enum to specify default audio / video quality - tehkillerbee_
+* Bugfix: Recent TIDAL changes resulted in missing Mix not causing a ObjectNotFound exception. - tehkillerbee_
 * Bugfix: Ensure manifest.codecs always uses a Codec type for both MPD and BTS. - tehkillerbee_
 * Added additional tests to verify stream formats (Relates to #252) - tehkillerbee_
 * BREAKING: Fix naming of getters to align with python naming convention and avoid confusion (Fixes #255) - tehkillerbee_
 * Bugfix: Use correct internal type int for relevant IDs (Fixes #260) - tehkillerbee_
 * Bugfix: Fix linting for audio_modes. Update tests (Fixes #261) - tehkillerbee_
-* Feat.: Provide "Share Link", "Listen link" as an attribute to album/artist/media. Add relevant tests (Fixes #266) - tehkillerbee_
+* Feat.: Provide "Share Link", "Listen link" as an attribute to album/artist/media/playlist/. Update relevant tests (Fixes #266) - tehkillerbee_
 * Allow switching authentication method oauth/pkce for tests. Default: oauth - tehkillerbee_
 * Tests: Added track stream tests (BTS, MPD) - tehkillerbee_
 * Bugfix: Always use last element in segment timeline. (Fixes #273) - tehkillerbee_

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -24,6 +24,7 @@ from dateutil import tz
 
 import tidalapi
 from tidalapi.album import Album
+from tidalapi.media import Quality
 from tidalapi.exceptions import MetadataNotAvailable, ObjectNotFound
 
 from .cover import verify_image_cover, verify_video_cover
@@ -159,3 +160,32 @@ def test_album_type_single(session):
 def test_album_type_ep(session):
     album = session.album(289261563)
     assert album.type == "EP"
+
+
+def test_album_quality_atmos(session):
+    # Session should allow highest possible quality (but will fallback to highest available album quality)
+    session.audio_quality = Quality.hi_res_lossless
+    album = session.album("355472560")  # DOLBY_ATMOS
+    assert album.audio_quality == "LOW"
+    assert album.audio_modes == ["DOLBY_ATMOS"]
+    assert "DOLBY_ATMOS" in album.media_metadata_tags
+
+
+def test_album_quality_max(session):
+    # Session should allow highest possible quality (but will fallback to highest available album quality)
+    session.audio_quality = Quality.hi_res_lossless
+    album = session.album("355473696")  # MAX (LOSSLESS, 16bit/48kHz)
+    assert album.audio_quality == "LOSSLESS"
+    assert album.audio_modes == ["STEREO"]
+    assert "LOSSLESS" in album.media_metadata_tags
+
+
+def test_album_quality_max_lossless(session):
+    # Session should allow highest possible quality (but will fallback to highest available album quality)
+    session.audio_quality = Quality.hi_res_lossless
+    album = session.album("355473675")  # MAX (HI_RES_LOSSLESS, 24bit/192kHz)
+    assert (
+        album.audio_quality == "LOSSLESS"
+    )  # Expected HI_RES_LOSSLESS here. TIDAL bug perhaps?
+    assert album.audio_modes == ["STEREO"]
+    assert "HIRES_LOSSLESS" in album.media_metadata_tags

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -24,8 +24,8 @@ from dateutil import tz
 
 import tidalapi
 from tidalapi.album import Album
-from tidalapi.media import Quality
 from tidalapi.exceptions import MetadataNotAvailable, ObjectNotFound
+from tidalapi.media import Quality
 
 from .cover import verify_image_cover, verify_video_cover
 

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -36,15 +36,22 @@ def test_album(session):
     assert album.type == "ALBUM"
     assert album.duration == 6712
     assert album.available
+    assert album.ad_supported_ready
+    assert album.allow_streaming
+    assert album.dj_ready
+    assert album.audio_modes == ["STEREO"]
+    assert album.audio_quality == "LOSSLESS"
     assert album.num_tracks == 22
     assert album.num_videos == 0
     assert album.num_volumes == 2
     assert album.release_date == datetime.datetime(2011, 9, 22)
+    assert album.available_release_date == datetime.datetime(2011, 9, 22)
     assert album.copyright == "Sinuz Recordings (a division of HITT bv)"
     assert album.version == "Deluxe"
     assert album.cover == "30d83a8c-1db6-439d-84b4-dbfb6f03c44c"
     assert album.video_cover is None
     assert album.explicit is False
+    assert album.premium_streaming_only is False
     assert album.universal_product_number == "3610151683488"
     assert 0 < album.popularity < 100
     assert album.artist.name == "Lasgo"

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -25,7 +25,7 @@ from dateutil import tz
 import tidalapi
 from tidalapi.album import Album
 from tidalapi.exceptions import MetadataNotAvailable, ObjectNotFound
-from tidalapi.media import Quality, AudioMode
+from tidalapi.media import AudioMode, Quality
 
 from .cover import verify_image_cover, verify_video_cover
 

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -56,7 +56,6 @@ def test_get_albums(session):
         session.album(17927863),
         session.album(36292296),
         session.album(17925106),
-        session.album(17782044),
         session.album(17926279),
     ]
 
@@ -93,7 +92,6 @@ def test_get_top_tracks(session):
         session.track(17927865),
         session.track(17927867),
         session.track(17926280),
-        session.track(17782052),
         session.track(17927869),
     ]
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -27,9 +27,9 @@ from tidalapi.exceptions import MetadataNotAvailable, ObjectNotFound
 from tidalapi.media import (
     AudioExtensions,
     AudioMode,
+    Codec,
     ManifestMimeType,
     MimeType,
-    Codec,
     Quality,
 )
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -428,8 +428,8 @@ def test_get_track_radio_limit_100(session):
 
 def test_get_stream_bts(session):
     track = session.track(77646170)  # Beck: Sea Change, Track: The Golden Age
-    # Set session as BTS type (i.e. HIGH Quality)
-    session.audio_quality = "HIGH"
+    # Set session as BTS type (i.e. low_320k/HIGH Quality)
+    session.audio_quality = Quality.low_320k
     # Attempt to get stream and validate
     stream = track.get_stream()
     validate_stream(stream, False)
@@ -444,7 +444,7 @@ def test_get_stream_bts(session):
 def test_get_stream_mpd(session):
     track = session.track(77646170)
     # Set session as MPD/DASH type (i.e. HI_RES_LOSSLESS Quality).
-    session.audio_quality = "HI_RES_LOSSLESS"
+    session.audio_quality = Quality.hi_res_lossless
     # Attempt to get stream and validate
     stream = track.get_stream()
     validate_stream(stream, True)
@@ -458,7 +458,7 @@ def test_manifest_element_count(session):
     #   and must be handled slightly differently when parsing the stream manifest DashInfo
     track = session.track(281047832)
     # Set session as MPD/DASH type (i.e. HI_RES_LOSSLESS Quality).
-    session.audio_quality = "HI_RES_LOSSLESS"
+    session.audio_quality = Quality.hi_res_lossless
     # Attempt to get stream
     stream = track.get_stream()
     # Get parsed stream manifest
@@ -469,9 +469,9 @@ def validate_stream(stream, is_hi_res_lossless: bool = False):
     assert stream.album_peak_amplitude == 1.0
     assert stream.album_replay_gain == -11.8
     assert stream.asset_presentation == "FULL"
-    assert stream.audio_mode == "STEREO"
+    assert stream.audio_mode == AudioMode.stereo
     if not is_hi_res_lossless:
-        assert stream.audio_quality == "HIGH"
+        assert stream.audio_quality == Quality.low_320k
         assert stream.is_bts == True
         assert stream.is_mpd == False
         assert stream.bit_depth == 16
@@ -481,7 +481,7 @@ def validate_stream(stream, is_hi_res_lossless: bool = False):
         assert audio_resolution[0] == 16
         assert audio_resolution[1] == 44100
     else:
-        assert stream.audio_quality == "HI_RES_LOSSLESS"
+        assert stream.audio_quality == Quality.hi_res_lossless
         assert stream.is_bts == False
         assert stream.is_mpd == True
         assert stream.bit_depth == 24
@@ -499,7 +499,7 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
     if not is_hi_res_lossless:
         assert manifest.is_bts == True
         assert manifest.is_mpd == False
-        assert manifest.codecs == "MP4A"
+        assert manifest.codecs == Codec.MP4A
         assert manifest.dash_info is None
         assert manifest.encryption_key is None
         assert manifest.encryption_type == "NONE"
@@ -511,7 +511,7 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
     else:
         assert manifest.is_bts == False
         assert manifest.is_mpd == True
-        assert manifest.codecs == "flac"
+        assert manifest.codecs == Codec.FLAC
         assert manifest.dash_info is not None
         assert manifest.encryption_key is None
         assert manifest.encryption_type == "NONE"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -290,8 +290,8 @@ def validate_stream(stream, is_hi_res_lossless: bool = False):
     assert stream.audio_mode == "STEREO"
     if not is_hi_res_lossless:
         assert stream.audio_quality == "HIGH"
-        assert stream.is_BTS == True
-        assert stream.is_MPD == False
+        assert stream.is_bts == True
+        assert stream.is_mpd == False
         assert stream.bit_depth == 16
         assert stream.sample_rate == 44100
         assert stream.manifest_mime_type == ManifestMimeType.BTS
@@ -300,8 +300,8 @@ def validate_stream(stream, is_hi_res_lossless: bool = False):
         assert audio_resolution[1] == 44100
     else:
         assert stream.audio_quality == "HI_RES_LOSSLESS"
-        assert stream.is_BTS == False
-        assert stream.is_MPD == True
+        assert stream.is_bts == False
+        assert stream.is_mpd == True
         assert stream.bit_depth == 24
         assert stream.sample_rate == 192000  # HI_RES_LOSSLESS: 24bit/192kHz
         assert stream.manifest_mime_type == ManifestMimeType.MPD
@@ -315,8 +315,8 @@ def validate_stream(stream, is_hi_res_lossless: bool = False):
 
 def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
     if not is_hi_res_lossless:
-        assert manifest.is_BTS == True
-        assert manifest.is_MPD == False
+        assert manifest.is_bts == True
+        assert manifest.is_mpd == False
         assert manifest.codecs == "MP4A"
         assert manifest.dash_info is None
         assert manifest.encryption_key is None
@@ -327,8 +327,8 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
         assert manifest.mime_type == MimeType.audio_mp4
         assert manifest.sample_rate == 44100
     else:
-        assert manifest.is_BTS == False
-        assert manifest.is_MPD == True
+        assert manifest.is_bts == False
+        assert manifest.is_mpd == True
         assert manifest.codecs == "flac"
         assert manifest.dash_info is not None
         assert manifest.encryption_key is None

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -521,3 +521,8 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
         assert manifest.mime_type == MimeType.audio_mp4
         assert manifest.sample_rate == 192000
     # TODO Validate stream URL contents
+
+
+def test_reset_session_quality(session):
+    # HACK: Make sure to reset audio quality to default value for remaining tests
+    session.audio_quality = Quality.default

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -405,7 +405,7 @@ def test_full_name_track_3(session):
 def test_track_media_metadata_tags(session):
     track = session.track(182912246)
     assert track.name == "All You Ever Wanted"
-    assert track.media_metadata_tags == ["LOSSLESS", "HIRES_LOSSLESS", "MQA"]
+    assert track.media_metadata_tags == ["LOSSLESS", "HIRES_LOSSLESS"]
 
 
 def test_get_track_radio_limit_default(session):

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -45,3 +45,13 @@ def test_mix_unavailable(session):
 def test_mixv2_unavailable(session):
     with pytest.raises(ObjectNotFound):
         mix = session.mixv2("12345678")
+
+
+@pytest.mark.skip(reason="Cannot test against user specific mixes")
+def test_mix_available(session):
+    mix = session.mix("016edb91bc504e618de6918b11b25b")
+
+
+@pytest.mark.skip(reason="Cannot test against user specific mixes")
+def test_mixv2_available(session):
+    mix = session.mixv2("016edb91bc504e618de6918b11b25b")

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -106,13 +106,13 @@ def test_video_playlist(session):
     )
     assert playlist.duration == 1996
     assert playlist.last_updated == datetime.datetime(
-        2020, 3, 25, 8, 5, 33, 115000, tzinfo=tz.tzutc()
+        2024, 8, 14, 16, 26, 58, 898000, tzinfo=tz.tzutc()
     )
     assert playlist.created == datetime.datetime(
         2017, 1, 23, 18, 34, 56, 930000, tzinfo=tz.tzutc()
     )
     assert playlist.type == "EDITORIAL"
-    assert playlist.public is True
+    assert playlist.public is False
     assert playlist.promoted_artists[0].name == "Sundance Film Festival"
 
     creator = playlist.creator

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -57,6 +57,15 @@ def test_playlist(session):
     assert creator.name == "JAY Z"
     assert isinstance(creator, tidalapi.Artist)
 
+    assert (
+        playlist.listen_url
+        == "https://listen.tidal.com/playlist/7eafb342-141a-4092-91eb-da0012da3a19"
+    )
+    assert (
+        playlist.share_url
+        == "https://tidal.com/browse/playlist/7eafb342-141a-4092-91eb-da0012da3a19"
+    )
+
 
 def test_updated_playlist(session):
     playlist = session.playlist("944dd087-f65c-4954-a9a3-042a574e86e3")

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -67,7 +67,7 @@ class Album:
     popularity: Optional[int] = -1
     user_date_added: Optional[datetime] = None
     audio_quality: Optional[str] = ""
-    audio_modes: Optional[str] = ""
+    audio_modes: Optional[List[str]] = [""]
     media_metadata_tags: Optional[List[str]] = [""]
 
     artist: Optional["Artist"] = None

--- a/tidalapi/album.py
+++ b/tidalapi/album.py
@@ -43,7 +43,7 @@ class Album:
     name, cover and video cover. TIDAL does this to reduce the network load.
     """
 
-    id: Optional[str] = None
+    id: Optional[int] = -1
     name: Optional[str] = None
     cover = None
     video_cover = None

--- a/tidalapi/artist.py
+++ b/tidalapi/artist.py
@@ -40,7 +40,7 @@ DEFAULT_ARTIST_IMG = "1e01cdb6-f15d-4d8b-8440-a047976c1cac"
 
 
 class Artist:
-    id: Optional[str] = None
+    id: Optional[int] = -1
     name: Optional[str] = None
     roles: Optional[List["Role"]] = None
     role: Optional["Role"] = None

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -184,7 +184,7 @@ class Media:
     actual media, use the release date of the album.
     """
 
-    id: Optional[str] = None
+    id: Optional[int] = -1
     name: Optional[str] = None
     duration: Optional[int] = -1
     available: bool = True

--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -59,6 +59,7 @@ class Quality(str, Enum):
     high_lossless: str = "LOSSLESS"
     hi_res: str = "HI_RES"
     hi_res_lossless: str = "HI_RES_LOSSLESS"
+    default: str = low_320k
 
     def __str__(self) -> str:
         return self.value
@@ -69,6 +70,7 @@ class VideoQuality(str, Enum):
     medium: str = "MEDIUM"
     low: str = "LOW"
     audio_only: str = "AUDIO_ONLY"
+    default: str = high
 
     def __str__(self) -> str:
         return self.value

--- a/tidalapi/mix.py
+++ b/tidalapi/mix.py
@@ -104,10 +104,14 @@ class Mix:
         else:
             result = self.session.parse_page(request.json())
             assert not isinstance(result, list)
-            self._retrieved = True
-            self.__dict__.update(result.categories[0].__dict__)
-            self._items = result.categories[1].items
-            return self
+            if len(result.categories) <= 1:
+                # An empty page with no mixes was returned. Assume that the selected mix was not available
+                raise ObjectNotFound("Mix not found")
+            else:
+                self._retrieved = True
+                self.__dict__.update(result.categories[0].__dict__)
+                self._items = result.categories[1].items
+                return self
 
     def parse(self, json_obj: JsonObj) -> "Mix":
         """Parse a mix into a :class:`Mix`, replaces the calling object.
@@ -188,6 +192,8 @@ class MixV2:
     sub_title_text_info: Optional[TextInfo] = None
     sub_title: Optional[str] = None
     updated: Optional[datetime] = None
+    _retrieved = False
+    _items: Optional[List[Union["Video", "Track"]]] = None
 
     def __init__(self, session: Session, mix_id: str):
         self.session = session
@@ -215,8 +221,15 @@ class MixV2:
         else:
             result = self.session.parse_page(request.json())
             assert not isinstance(result, list)
-            self.__dict__.update(result.categories[0].__dict__)
-            return self
+
+            if len(result.categories) <= 1:
+                # An empty page with no mixes was returned. Assume that the selected mix was not available
+                raise ObjectNotFound("Mix not found")
+            else:
+                self._retrieved = True
+                self.__dict__.update(result.categories[0].__dict__)
+                self._items = result.categories[1].items
+                return self
 
     def parse(self, json_obj: JsonObj) -> "MixV2":
         """Parse a mix into a :class:`MixV2`, replaces the calling object.

--- a/tidalapi/mix.py
+++ b/tidalapi/mix.py
@@ -178,15 +178,15 @@ class MixV2:
     # tehkillerbee: TODO Doesn't look like this is using the v2 endpoint anyways!?
 
     date_added: Optional[datetime] = None
-    title: str = ""
-    id: str = ""
+    title: Optional[str] = None
+    id: Optional[str] = None
     mix_type: Optional[MixType] = None
     images: Optional[ImageResponse] = None
     detail_images: Optional[ImageResponse] = None
     master = False
     title_text_info: Optional[TextInfo] = None
     sub_title_text_info: Optional[TextInfo] = None
-    sub_title: str = ""
+    sub_title: Optional[str] = None
     updated: Optional[datetime] = None
 
     def __init__(self, session: Session, mix_id: str):

--- a/tidalapi/playlist.py
+++ b/tidalapi/playlist.py
@@ -60,6 +60,11 @@ class Playlist:
     user_date_added: Optional[datetime] = None
     _etag: Optional[str] = None
 
+    # Direct URL to https://listen.tidal.com/playlist/<playlist_id>
+    listen_url: str = ""
+    # Direct URL to https://tidal.com/browse/playlist/<playlist_id>
+    share_url: str = ""
+
     def __init__(self, session: "Session", playlist_id: Optional[str]):
         self.id = playlist_id
         self.session = session
@@ -125,6 +130,9 @@ class Playlist:
             self.creator = self.session.parse_artist(creator)
         else:
             self.creator = self.session.parse_user(creator) if creator else None
+
+        self.listen_url = f"{self.session.config.listen_base_url}/playlist/{self.id}"
+        self.share_url = f"{self.session.config.share_base_url}/playlist/{self.id}"
 
         return copy.copy(self)
 

--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -154,7 +154,11 @@ class Requests(object):
             self.latest_err_response = request
             if request.content:
                 resp = request.json()
-                log.debug("Request response: '%s'", resp["errors"][0]["detail"])
+                # Make sure request response contains the detailed error message
+                if "errors" in resp:
+                    log.debug("Request response: '%s'", resp["errors"][0]["detail"])
+                else:
+                    log.debug("Request response: '%s'", resp["userMessage"])
             if request.status_code and request.status_code == 404:
                 raise ObjectNotFound
             elif request.status_code and request.status_code == 429:

--- a/tidalapi/request.py
+++ b/tidalapi/request.py
@@ -157,8 +157,11 @@ class Requests(object):
                 # Make sure request response contains the detailed error message
                 if "errors" in resp:
                     log.debug("Request response: '%s'", resp["errors"][0]["detail"])
-                else:
+                elif "userMessage" in resp:
                     log.debug("Request response: '%s'", resp["userMessage"])
+                else:
+                    log.debug("Request response: '%s'", json.dumps(resp))
+
             if request.status_code and request.status_code == 404:
                 raise ObjectNotFound
             elif request.status_code and request.status_code == 429:

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -126,8 +126,8 @@ class Config:
     @no_type_check
     def __init__(
         self,
-        quality: str = media.Quality.low_320k,
-        video_quality: str = media.VideoQuality.high,
+        quality: str = media.Quality.default,
+        video_quality: str = media.VideoQuality.default,
         item_limit: int = 1000,
         alac: bool = True,
     ):


### PR DESCRIPTION
* Tests: Fix all tests that previously failed. 
* Bugfix: Recent TIDAL changes resulted in missing Mix not causing a ObjectNotFound exception. 
* Bugfix: Ensure manifest.codecs always uses Codec type for both MPD and BTS. 
* Added additional tests to verify stream formats (Relates to #252) 
* BREAKING: Fix naming of getters to align with python naming convention and avoid confusion (Fixes #255) - tehkillerbee_
* Bugfix: Use correct internal type int for relevant IDs (Fixes #260) 
* Bugfix: Fix linting for audio_modes. Update tests (Fixes #261)