### PR TITLE
Add optional fn_print to Session::login_session_file

### DIFF
--- a/docs/login.rst
+++ b/docs/login.rst
@@ -46,7 +46,7 @@ This will print the link, and then wait for the login future to complete, but it
 .. testcode::
 
     # The function is print by default, but you can use anything, here we do it to avoid the print being swallowed
-    session.login_oauth_simple(function=printer)
+    session.login_oauth_simple(fn_print=printer)
     print(session.check_login())
 
 .. testoutput::

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -446,12 +446,15 @@ class Session:
         self,
         session_file: Path,
         do_pkce: Optional[bool] = False,
+        fn_print: Callable[[str], None] = print
     ) -> bool:
         """Logs in to the TIDAL api using an existing OAuth/PKCE session file. If no
         session json file exists, a new one will be created after successful login.
 
         :param session_file: The session json file
         :param do_pkce: Perform PKCE login. Default: Use OAuth logon
+        :param fn_print: A function which will be called to print the the challenge text,
+            defaults to `print()`.
         :return: Returns true if we think the login was successful.
         """
         self.load_session_from_file(session_file)
@@ -460,10 +463,10 @@ class Session:
         if not self.check_login():
             if do_pkce:
                 log.info("Creating new session (PKCE)...")
-                self.login_pkce()
+                self.login_pkce(fn_print=fn_print)
             else:
                 log.info("Creating new session (OAuth)...")
-                self.login_oauth_simple()
+                self.login_oauth_simple(function=fn_print)
 
         if self.check_login():
             log.info("TIDAL Login OK")

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -466,7 +466,7 @@ class Session:
                 self.login_pkce(fn_print=fn_print)
             else:
                 log.info("Creating new session (OAuth)...")
-                self.login_oauth_simple(function=fn_print)
+                self.login_oauth_simple(fn_print=fn_print)
 
         if self.check_login():
             log.info("TIDAL Login OK")
@@ -579,17 +579,17 @@ class Session:
 
         return token
 
-    def login_oauth_simple(self, function: Callable[[str], None] = print) -> None:
+    def login_oauth_simple(self, fn_print: Callable[[str], None] = print) -> None:
         """Login to TIDAL using a remote link. You can select what function you want to
         use to display the link.
 
-        :param function: The function you want to display the link with
+        :param fn_print: The function you want to display the link with
         :raises: TimeoutError: If the login takes too long
         """
 
         login, future = self.login_oauth()
         text = "Visit https://{0} to log in, the code will expire in {1} seconds"
-        function(text.format(login.verification_uri_complete, login.expires_in))
+        fn_print(text.format(login.verification_uri_complete, login.expires_in))
         future.result()
 
     def login_oauth(self) -> Tuple[LinkLogin, concurrent.futures.Future[Any]]:

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -453,7 +453,7 @@ class Session:
 
         :param session_file: The session json file
         :param do_pkce: Perform PKCE login. Default: Use OAuth logon
-        :param fn_print: A function which will be called to print the the challenge text,
+        :param fn_print: A function which will be called to print the challenge text,
             defaults to `print()`.
         :return: Returns true if we think the login was successful.
         """

--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -446,7 +446,7 @@ class Session:
         self,
         session_file: Path,
         do_pkce: Optional[bool] = False,
-        fn_print: Callable[[str], None] = print
+        fn_print: Callable[[str], None] = print,
     ) -> bool:
         """Logs in to the TIDAL api using an existing OAuth/PKCE session file. If no
         session json file exists, a new one will be created after successful login.


### PR DESCRIPTION
As agreed, I have added the optional fn_print argument. The typing is the same used in login_pkce, so it's simply Callable[[str], None], but this should be good enough for the task.
Feel free to ask for any changes might be needed, thank you.
