### PR TITLE
Bugfix/291 bug playlistsandfavoriteplaylists endpoint appears broken

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -527,7 +527,7 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
         assert manifest.dash_info is None
         assert manifest.encryption_key is None
         assert manifest.encryption_type == "NONE"
-        assert manifest.file_extension == AudioExtensions.MP4
+        assert manifest.file_extension == AudioExtensions.M4A
         assert manifest.is_encrypted == False
         assert manifest.manifest_mime_type == ManifestMimeType.BTS
         assert manifest.mime_type == MimeType.audio_mp4
@@ -539,7 +539,7 @@ def validate_stream_manifest(manifest, is_hi_res_lossless: bool = False):
         assert manifest.dash_info is not None
         assert manifest.encryption_key is None
         assert manifest.encryption_type == "NONE"
-        assert manifest.file_extension == AudioExtensions.MP4
+        assert manifest.file_extension == AudioExtensions.FLAC
         assert manifest.is_encrypted == False
         assert manifest.manifest_mime_type == ManifestMimeType.MPD
         assert manifest.mime_type == MimeType.audio_mp4

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -24,7 +24,6 @@ from dateutil import tz
 
 import tidalapi
 from tidalapi.exceptions import ObjectNotFound
-
 from .cover import verify_image_cover, verify_image_resolution
 
 
@@ -267,6 +266,7 @@ def test_playlist_merge(session):
     tracks = [track.id for track in playlist.tracks()]
     for track in tracks:
         assert track in added_items
+    playlist.delete()
 
 
 def test_playlist_public_private(session):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -66,6 +66,7 @@ def test_get_playlist_folders(session):
     folder_ids = [folder.id for folder in session.user.playlist_folders()]
     assert folder.id in folder_ids
     folder.remove()
+    folder_ids = [folder.id for folder in session.user.playlist_folders()]
     assert folder.id not in folder_ids
 
 

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -187,8 +187,8 @@ class LoggedInUser(FetchedUser):
     ) -> List[Union["Playlist", "UserPlaylist"]]:
         """Get the (public) playlists created by the user.
 
-        :param offset: The amount of items you want returned.
         :param limit: The index of the first item you want included.
+        :param offset: The amount of items you want returned.
         :return: List of public playlists.
         """
         params = {"limit": limit, "offset": offset}
@@ -209,7 +209,7 @@ class LoggedInUser(FetchedUser):
         )
 
     def playlist_and_favorite_playlists(
-        self, limit: Optional[int] = None, offset: int = 0
+        self, offset: int = 0, limit: int = 50
     ) -> List[Union["Playlist", "UserPlaylist"]]:
         """Get the playlists created by the user, and the playlists favorited by the
         user. This function is limited to 50 by TIDAL, requiring pagination.


### PR DESCRIPTION
Revert incorrect default limit (Fixes #291). Use consistent offset/limit ordering.