### PR TITLE
Fix typo in session.py

### DIFF
--- a/tidalapi/session.py
+++ b/tidalapi/session.py
@@ -621,7 +621,7 @@ class Session:
                 "is_pkce": {"data": self.is_pkce},
                 # "expiry_time": {"data": self.expiry_time},
             }
-            with session_file.open("w") as outfile:
+            with open(session_file, "w") as outfile:
                 json.dump(data, outfile)
 
     def load_session_from_file(self, session_file: Path):


### PR DESCRIPTION
Corrected a minor syntax error on line 624 of session.py. The previous line used `with session_file.open("w")`, which is incorrect. This change updates it to `with open(session_file, "w")`, following the correct syntax for opening a file in write mode.

This is also my first PR, so I have no idea if I am doing this correctly.