### PR TITLE
Adhere to typing standards and mark Python current versions as supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Mark current non-EOL versions as supported - https://devguide.python.org/versions/

This project seems to make a great job at using typing, but forgot to advertise it, so tools like Pyright won't pick it up - https://typing.python.org/en/latest/spec/distributing.html#packaging-typed-libraries