### PR TITLE
Implement sorting for remaining favourites + playlists

### DIFF
--- a/tidalapi/playlist.py
+++ b/tidalapi/playlist.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
 
 from tidalapi.exceptions import ObjectNotFound, TooManyRequests
-from tidalapi.types import JsonObj, ItemOrder, OrderDirection
+from tidalapi.types import ItemOrder, JsonObj, OrderDirection
 from tidalapi.user import LoggedInUser
 
 if TYPE_CHECKING:

--- a/tidalapi/types.py
+++ b/tidalapi/types.py
@@ -5,15 +5,18 @@ from typing import Any, Dict
 
 JsonObj = Dict[str, Any]
 
+
 class AlbumOrder(Enum):
     Artist = "ARTIST"
     DateAdded = "DATE"
     Name = "NAME"
     ReleaseDate = "RELEASE_DATE"
 
+
 class ArtistOrder(Enum):
     DateAdded = "DATE"
     Name = "NAME"
+
 
 class ItemOrder(Enum):
     Album = "ALBUM"
@@ -23,19 +26,23 @@ class ItemOrder(Enum):
     Length = "LENGTH"
     Name = "NAME"
 
+
 class MixOrder(Enum):
     DateAdded = "DATE"
     MixType = "MIX_TYPE"
     Name = "NAME"
 
+
 class PlaylistOrder(Enum):
     DateCreated = "DATE"
     Name = "NAME"
+
 
 class VideoOrder(Enum):
     Artist = "ARTIST"
     DateAdded = "DATE"
     Name = "NAME"
+
 
 class OrderDirection(Enum):
     Ascending = "ASC"

--- a/tidalapi/user.py
+++ b/tidalapi/user.py
@@ -27,7 +27,16 @@ from typing import TYPE_CHECKING, List, Optional, Union, cast
 from urllib.parse import urljoin
 
 from tidalapi.exceptions import ObjectNotFound
-from tidalapi.types import JsonObj, AlbumOrder, ItemOrder, OrderDirection, PlaylistOrder, ArtistOrder, MixOrder, VideoOrder
+from tidalapi.types import (
+    AlbumOrder,
+    ArtistOrder,
+    ItemOrder,
+    JsonObj,
+    MixOrder,
+    OrderDirection,
+    PlaylistOrder,
+    VideoOrder,
+)
 
 if TYPE_CHECKING:
     from tidalapi.album import Album


### PR DESCRIPTION
This PR adds enums for the individual sorting types available per favourite and also implements them for all favourites and playlists.

I was not able to directly test the python code, but I did test the HTTP requests manually. Make Test run had some errors, but seems very unrelated to the changes here so I think we are good.

<details>
  <summary>Failed Tests</summary>

```  
================================================================================================================================================ short test summary info =================================================================================================================================================
FAILED tests/test_album.py::test_video_cover - FileNotFoundError: [Errno 2] No such file or directory: 'ffprobe'
FAILED tests/test_genres.py::test_get_items - tidalapi.exceptions.ObjectNotFound
FAILED tests/test_media.py::test_track_quality_low96k - tidalapi.exceptions.ObjectNotFound: Album not found
FAILED tests/test_media.py::test_track_quality_low320k - tidalapi.exceptions.ObjectNotFound: Album not found
FAILED tests/test_media.py::test_track_quality_lossless - tidalapi.exceptions.ObjectNotFound: Album not found
FAILED tests/test_media.py::test_video_url - FileNotFoundError: [Errno 2] No such file or directory: 'ffprobe'
FAILED tests/test_media.py::test_get_track_radio_limit_default - assert 99 == 100
FAILED tests/test_media.py::test_get_track_radio_limit_100 - assert 99 == 100
FAILED tests/test_mix.py::test_mix - requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://api.tidal.com/v1/pages/my_collection_my_mixes<redacted>
FAILED tests/test_page.py::test_get_explore_items - AssertionError: assert 'Featured' == 'Genres'
FAILED tests/test_page.py::test_hires_page - AssertionError: assert 'K-Pop: Headphone Classics' == 'Electronic: ...hone Classics'
FAILED tests/test_page.py::test_for_you - AssertionError: assert 'My Mix 1' == 'My Daily Discovery'
FAILED tests/test_page.py::test_page_links - requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://api.tidal.com/v1/pages/mood_love<redacted>
FAILED tests/test_page.py::test_moods - AssertionError: assert 'For DJs' == 'Holidays'
FAILED tests/test_page.py::test_mixes - AssertionError: assert 'My Mix 1' == 'My Daily Discovery'
FAILED tests/test_page.py::test_album_page - requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://api.tidal.com/v1/pages/album<redacted>
FAILED tests/test_playlist.py::test_playlist_add_isrc - AssertionError: assert False
FAILED tests/test_session.py::test_config - AssertionError: assert <VideoQuality.low: 'LOW'> == <VideoQuality.high: 'HIGH'>
FAILED tests/test_session.py::test_video_quality_defaults_to_best - AssertionError: assert <VideoQuality.low: 'LOW'> == 'HIGH'
FAILED tests/test_user.py::test_add_remove_favorite_video - requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.tidal.com/v1/users/184335975/favorites/videos<redacted>
=========================================================================================================================== 20 failed, 118 passed, 7 skipped, 4 warnings in 143.46s (0:02:23) ============================================================================================================================
```
  
</details>

Closes #212 