### PR TITLE
fix: Handle missing track metadata tags in parse_track

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -304,7 +304,7 @@ class Track(Media):
         self.audio_quality = json_obj["audioQuality"]
         self.audio_modes = json_obj["audioModes"]
         self.version = json_obj["version"]
-        self.media_metadata_tags = json_obj["mediaMetadata"]["tags"]
+        self.media_metadata_tags = json_obj.get("mediaMetadata", {}).get("tags", {})
 
         if self.version is not None:
             self.full_name = f"{json_obj['title']} ({json_obj['version']})"


### PR DESCRIPTION
I'm not sure if this is a recent change in the Tidal API, but I could reproduce the error on at least two different devices:

```
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python3.10/dist-packages/mopidy_tidal/workers.py", line 7, in func_wrapper
    items = f(*args)
  File "/usr/local/lib/python3.10/dist-packages/tidalapi/playlist.py", line 159, in tracks
    self.request.map_json(
  File "/usr/local/lib/python3.10/dist-packages/tidalapi/request.py", line 218, in map_json
    return list(map(parse, items))
  File "/usr/local/lib/python3.10/dist-packages/tidalapi/media.py", line 302, in parse_track
    self.media_metadata_tags = json_obj["mediaMetadata"]["tags"]
TypeError: 'NoneType' object is not subscriptable
```

This PR makes `parse_track` more conservative my handling both missing metadata and missing tags.