### PR TITLE
fix: A more robust way of handling mediaMetadata on unavailable tracks

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -304,7 +304,7 @@ class Track(Media):
         self.audio_quality = json_obj["audioQuality"]
         self.audio_modes = json_obj["audioModes"]
         self.version = json_obj["version"]
-        self.media_metadata_tags = json_obj.get("mediaMetadata", {}).get("tags", {})
+        self.media_metadata_tags = (json_obj.get("mediaMetadata") or {}).get("tags", {})
 
         if self.version is not None:
             self.full_name = f"{json_obj['title']} ({json_obj['version']})"


### PR DESCRIPTION
This is a more robust fix for https://github.com/EbbLabs/python-tidal/pull/382.

What I didn't notice is that the case I covered was the one where `mediaMetadata` was actually populated but it was empty, but apparently there can also be paths where the key is completely missing so we still end up dereferencing a null.

```
ERROR    2025-12-02 01:09:49,035 [613:ThreadPoolExecutor-6_1] tidalapi.workers
  Failed to run >(limit=50, offset=2900, args=[None, None])
ERROR    2025-12-02 01:09:49,036 [613:ThreadPoolExecutor-6_1] tidalapi.workers
  'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/home/blacklight/.local/lib/python3.13/site-packages/tidalapi/workers.py", line 15, in func_wrapper
    items = func(limit, offset, *extra_args)
  File "/home/blacklight/.local/lib/python3.13/site-packages/tidalapi/playlist.py", line 230, in tracks
    self.request.map_json(
    ~~~~~~~~~~~~~~~~~~~~~^
        json_obj=request.json(), parse=self.session.parse_track
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/blacklight/.local/lib/python3.13/site-packages/tidalapi/request.py", line 247, in map_json
    return list(map(parse, items))
  File "/home/blacklight/.local/lib/python3.13/site-packages/tidalapi/session.py", line 281, in parse_track
    return self.track().parse_track(obj, album)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/blacklight/.local/lib/python3.13/site-packages/tidalapi/media.py", line 307, in parse_track
    self.media_metadata_tags = json_obj.get("mediaMetadata", {}).get("tags", {})
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

This should fix it in all the cases.