### PR TITLE
fix: Fix Media `id` type

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -180,7 +180,7 @@ class Media:
     actual media, use the release date of the album.
     """
 
-    id: int
+    id: str
     title: str
     name: str  # aka. title
     duration: int  # Duration, in seconds


### PR DESCRIPTION
It looks like the `id` here should be a string, not int.