### PR TITLE
chore(media): Don't suppress original exception in ManifestDecodeError

### DIFF
--- a/tidalapi/media.py
+++ b/tidalapi/media.py
@@ -609,8 +609,8 @@ class Stream:
         try:
             # Stream Manifest is base64 encoded.
             return base64.b64decode(self.manifest).decode("utf-8")
-        except:
-            raise ManifestDecodeError
+        except Exception as e:
+            raise ManifestDecodeError from e
 
     @property
     def is_mpd(self) -> bool:
@@ -761,15 +761,15 @@ class DashInfo:
         try:
             if stream.is_mpd and not stream.is_encrypted:
                 return DashInfo(stream.get_manifest_data())
-        except:
-            raise ManifestDecodeError
+        except Exception as e:
+            raise ManifestDecodeError from e
 
     @staticmethod
     def from_mpd(mpd_manifest) -> "DashInfo":
         try:
             return DashInfo(mpd_manifest)
-        except:
-            raise ManifestDecodeError
+        except Exception as e:
+            raise ManifestDecodeError from e
 
     def __init__(self, mpd_xml):
         mpd = MPEGDASHParser.parse(


### PR DESCRIPTION
The purpose of this commit is to improve error handling when decoding the manifest in the tidalapi library.

Instead of suppressing the original exception when a manifest decoding error occurs, it now chains the original exception to the ManifestDecodeError.

Reference: #396